### PR TITLE
Add roster cutdown decision queue, integrate into GM queue and UI

### DIFF
--- a/docs/gm-decision-queue-roster-cutdown-v3-audit.md
+++ b/docs/gm-decision-queue-roster-cutdown-v3-audit.md
@@ -6,7 +6,9 @@
 
 `DEPTH_NEEDS` is a positional construction template and is not consulted or summed. The limits come only from `ROSTER_LIMITS`, through the shared legality helper or the explicit preseason advance gate.
 
-League legality builds membership from players with a team ID and excludes recorded `free_agent` status. The decision context is deliberately more conservative: it counts only supplied-team players explicitly recorded as `active` or `injured_reserve` (including legacy `onIR: true`). Thus IR counts under the current legality model, while free agents, prospects, retired players, foreign ownership, unresolved references, duplicates, and unknown statuses do not increase queue urgency. Unknown and partial data produce deterministic diagnostics. A missing phase makes limit context unavailable rather than defaulting to 53.
+League legality builds membership from team ownership and excludes recorded `free_agent` status. The decision context uses the same rule: supplied-team players count regardless of whether status is `active`, `injured_reserve`, missing, or nonstandard, while recorded free agents, foreign ownership, unresolved references, and duplicates do not count. IR therefore follows the same ownership rule. Missing and nonstandard statuses remain in `currentCount` and produce deterministic diagnostics rather than disappearing from the legality context. A missing phase makes limit context unavailable rather than defaulting to 53.
+
+This PR supersedes #1760 by carrying both corrected gameplay-parity roster membership counting and the canonical `Team:Roster / Depth` navigation fix.
 
 ## Review context and omitted claims
 

--- a/docs/gm-decision-queue-roster-cutdown-v3-audit.md
+++ b/docs/gm-decision-queue-roster-cutdown-v3-audit.md
@@ -1,0 +1,23 @@
+# GM Decision Queue roster cutdown V3 audit
+
+## Authorities verified
+
+`getRosterLimitForPhase()` in `src/core/teamValidation.js` is the shared transaction and league-legality authority. It selects the existing 90-player offseason limit for offseason re-signing, free agency, draft, offseason, and preseason transaction legality, and the existing 53-player regular-season limit otherwise. Separately, the preseason `ADVANCE_WEEK` handler in `src/worker/worker.js` explicitly blocks an interactive user with more than `Constants.ROSTER_LIMITS.REGULAR_SEASON` players before starting the season. The queue therefore uses that proven 53-player preseason transition constraint and labels it critical; other proven phase-limit violations are high.
+
+`DEPTH_NEEDS` is a positional construction template and is not consulted or summed. The limits come only from `ROSTER_LIMITS`, through the shared legality helper or the explicit preseason advance gate.
+
+League legality builds membership from players with a team ID and excludes recorded `free_agent` status. The decision context is deliberately more conservative: it counts only supplied-team players explicitly recorded as `active` or `injured_reserve` (including legacy `onIR: true`). Thus IR counts under the current legality model, while free agents, prospects, retired players, foreign ownership, unresolved references, duplicates, and unknown statuses do not increase queue urgency. Unknown and partial data produce deterministic diagnostics. A missing phase makes limit context unavailable rather than defaulting to 53.
+
+## Review context and omitted claims
+
+The feature emits at most one team-level `roster_cutdown` item. Candidate rows are nested factual review context, never queue cards. They use canonical player presentation role, canonical position, replacement difficulty when present, and factual same-position counts. Their deterministic order is neutral position then canonical player ID; there is no cut score, ideal positional target, OVR/age/salary rank, or release recommendation.
+
+The release handlers validate ownership and perform mutations inside the worker. No reusable, mutation-free release-eligibility preview was found, so the queue makes no releasability claim. Contract-obligation code can calculate release dead money, but the live release path also owns phase treatment and mutation; this PR intentionally exposes no cap savings, dead money, guarantee, or June 1 estimate and adds no cap math.
+
+## Queue, UI, and performance
+
+Combined ordering is severity, then explicit category order (availability, `roster_cutdown`, contract), then existing stable keys. This preserves availability ahead of same-severity reminders while ranking the team constraint ahead of contracts. Team subjects bypass player overlap buckets, preserving availability-versus-contract deferral. The UI renders only the existing top three decisions and routes the compact team item through the canonical `Team:Roster / Depth` destination recognized by management destination normalization and TeamHub.
+
+The combined builder's presentation cache is shared across availability, contracts, and cutdown candidates. Membership and duplicate filters run before presentation work, and every resolved candidate presentation is built at most once.
+
+No AI roster behavior, transaction execution, simulation, worker behavior, persistence, cap formulas, save schema, or player data is changed. No worker call, persistence write, randomness, or input mutation occurs in the new pure model.

--- a/src/core/__tests__/gmDecisionQueue.test.js
+++ b/src/core/__tests__/gmDecisionQueue.test.js
@@ -9,7 +9,7 @@ import {
   createContractDecisionQueueBuilder,
   createGMDecisionQueueBuilder,
 } from '../gmDecisionQueue.js';
-import { getRosterLimitForPhase } from '../teamValidation.js';
+import { getRosterLimitForPhase, validateLeagueTeamLegality } from '../teamValidation.js';
 import { buildPlayerDecisionPresentation } from '../playerDecisionPresentation.js';
 
 const player = (id, overrides = {}) => ({
@@ -48,17 +48,32 @@ describe('roster cutdown decisions', () => {
     expect(buildRosterCutdownDecisionQueue(input).items[0]).toMatchObject({ severity: 'critical', rosterConstraint: { limit: 53, requiredMoves: 1 } });
   });
 
-  it('deduplicates references and conservatively omits foreign, excluded, and status-unknown players', () => {
+  it('matches gameplay membership for missing statuses while excluding duplicates, foreign players, and recorded free agents', () => {
     const active = rosterPlayer(1);
     const ir = rosterPlayer(2, { status: 'injured_reserve', onIR: true });
+    const missing = rosterPlayer(5, { status: null });
+    const legacy = rosterPlayer(6, { status: 'legacy_roster' });
     const result = buildRosterLimitContext({
-      roster: [active, { ...active }, ir, rosterPlayer(3, { teamId: 11 }), rosterPlayer(4, { status: 'free_agent' }), rosterPlayer(5, { status: null })],
+      roster: [active, { ...active }, ir, rosterPlayer(3, { teamId: 11 }), rosterPlayer(4, { status: 'free_agent' }), missing, legacy],
       team: { id: 10 }, league: { phase: 'regular', players: [] },
     });
-    expect(result.currentCount).toBe(2);
+    expect(result.currentCount).toBe(4);
     expect(result.diagnostics.map((entry) => entry.reason)).toEqual(expect.arrayContaining([
-      'Duplicate roster reference', 'Player not owned by supplied team', 'Status does not count toward constrained roster', 'Roster-counting status unavailable',
+      'Duplicate roster reference', 'Player not owned by supplied team', 'Recorded free agent excluded from roster count',
+      'Roster status unavailable; counted by team ownership', 'Nonstandard roster status "legacy_roster"; counted by team ownership',
     ]));
+  });
+
+  it('matches legality at 55 owned players when four statuses are missing', () => {
+    const input = rosterInput(55);
+    input.roster.slice(0, 4).forEach((row) => { delete row.status; });
+    const context = buildRosterLimitContext(input);
+    const legality = validateLeagueTeamLegality({ teams: [input.team], players: input.roster, phase: 'regular' });
+
+    expect(context).toMatchObject({ currentCount: 55, limit: 53, requiredMoves: 2, overLimit: true });
+    expect(context.diagnostics.filter((entry) => entry.reason === 'Roster status unavailable; counted by team ownership')).toHaveLength(4);
+    expect(legality.rosterLimit).toBe(53);
+    expect(legality.issues).toContainEqual(expect.objectContaining({ code: 'roster_limit', message: expect.stringContaining('55/53') }));
   });
 
   it('never invents a limit for missing phase data and remains pure and deterministic', () => {

--- a/src/core/__tests__/gmDecisionQueue.test.js
+++ b/src/core/__tests__/gmDecisionQueue.test.js
@@ -3,10 +3,13 @@ import {
   buildAvailabilityDecisionQueue,
   buildContractDecisionQueue,
   buildGMDecisionQueue,
+  buildRosterLimitContext,
+  buildRosterCutdownDecisionQueue,
   createAvailabilityDecisionQueueBuilder,
   createContractDecisionQueueBuilder,
   createGMDecisionQueueBuilder,
 } from '../gmDecisionQueue.js';
+import { getRosterLimitForPhase } from '../teamValidation.js';
 import { buildPlayerDecisionPresentation } from '../playerDecisionPresentation.js';
 
 const player = (id, overrides = {}) => ({
@@ -17,6 +20,67 @@ const player = (id, overrides = {}) => ({
 const build = (roster, overrides = {}) => buildAvailabilityDecisionQueue({
   roster, team: { id: 10, depthChart: { QB: roster.filter(Boolean).map((p) => p.id) } },
   league: { players: roster.filter((p) => p && typeof p === 'object'), draftClass: [] }, ...overrides,
+});
+
+describe('roster cutdown decisions', () => {
+  const rosterPlayer = (id, overrides = {}) => player(id, { injury: null, ...overrides });
+  const rosterInput = (count, overrides = {}) => {
+    const roster = Array.from({ length: count }, (_, index) => rosterPlayer(index + 1));
+    return { roster, team: { id: 10, roster }, league: { phase: 'regular', players: roster }, ...overrides };
+  };
+
+  it('uses the gameplay roster authority and only emits one team constraint when over limit', () => {
+    expect(buildRosterLimitContext(rosterInput(53))).toMatchObject({ currentCount: 53, limit: getRosterLimitForPhase('regular'), requiredMoves: 0, overLimit: false });
+    expect(buildRosterCutdownDecisionQueue(rosterInput(52)).items).toEqual([]);
+    const result = buildRosterCutdownDecisionQueue(rosterInput(55));
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: 'roster_cutdown:10', subject: { type: 'team', teamId: 10 }, severity: 'high',
+      rosterConstraint: { currentCount: 55, limit: 53, requiredMoves: 2 },
+    });
+    expect(result.items[0].rosterConstraint.candidates).toHaveLength(55);
+    expect(result.items[0].rosterConstraint.candidates.every((candidate) => !('recommendation' in candidate))).toBe(true);
+  });
+
+  it('uses the proven preseason advance gate and marks that blocker critical', () => {
+    const input = rosterInput(54);
+    input.league.phase = 'preseason';
+    expect(buildRosterCutdownDecisionQueue(input).items[0]).toMatchObject({ severity: 'critical', rosterConstraint: { limit: 53, requiredMoves: 1 } });
+  });
+
+  it('deduplicates references and conservatively omits foreign, excluded, and status-unknown players', () => {
+    const active = rosterPlayer(1);
+    const ir = rosterPlayer(2, { status: 'injured_reserve', onIR: true });
+    const result = buildRosterLimitContext({
+      roster: [active, { ...active }, ir, rosterPlayer(3, { teamId: 11 }), rosterPlayer(4, { status: 'free_agent' }), rosterPlayer(5, { status: null })],
+      team: { id: 10 }, league: { phase: 'regular', players: [] },
+    });
+    expect(result.currentCount).toBe(2);
+    expect(result.diagnostics.map((entry) => entry.reason)).toEqual(expect.arrayContaining([
+      'Duplicate roster reference', 'Player not owned by supplied team', 'Status does not count toward constrained roster', 'Roster-counting status unavailable',
+    ]));
+  });
+
+  it('never invents a limit for missing phase data and remains pure and deterministic', () => {
+    const input = rosterInput(54);
+    const snapshot = structuredClone(input);
+    delete input.league.phase;
+    const first = buildRosterLimitContext(input);
+    expect(first).toMatchObject({ currentCount: null, limit: null, requiredMoves: 0, overLimit: false, availableData: false });
+    expect(buildRosterLimitContext(input)).toEqual(first);
+    expect(buildRosterLimitContext({ ...input, league: { ...input.league, phase: 'unknown_future_phase' } }).limit).toBeNull();
+    expect({ ...input, league: { ...input.league, phase: snapshot.league.phase } }).toEqual(snapshot);
+  });
+
+  it('keeps team subjects out of player overlap buckets and shares presentation cache', () => {
+    const input = rosterInput(54);
+    input.roster[0].injury = { type: 'Knee', weeksRemaining: 2 };
+    const presentation = vi.fn(({ player: row }) => buildPlayerDecisionPresentation({ player: row, team: input.team, league: input.league }));
+    const result = createGMDecisionQueueBuilder({ buildPresentation: presentation })(input);
+    expect(result.items.filter((item) => item.category === 'roster_cutdown')).toHaveLength(1);
+    expect(result.items.some((item) => item.category === 'availability')).toBe(true);
+    expect(presentation).toHaveBeenCalledTimes(54);
+  });
 });
 
 describe('buildAvailabilityDecisionQueue', () => {

--- a/src/core/gmDecisionQueue.js
+++ b/src/core/gmDecisionQueue.js
@@ -1,4 +1,6 @@
 import { buildPlayerDecisionPresentation } from './playerDecisionPresentation.js';
+import { Constants } from './constants.js';
+import { getRosterLimitForPhase } from './teamValidation.js';
 
 const SEVERITY_RANK = { critical: 0, high: 1, medium: 2 };
 const ROLE_RANK = { Starter: 0, Backup: 1, Reserve: 2 };
@@ -18,6 +20,10 @@ const RETENTION_RECOMMENDATION_RANK = {
 const RETENTION_ROLE_RANK = { core_starter: 0, starter: 1, rotation: 2, depth: 3 };
 const MARKET_RANK = { high: 0, medium: 1, low: 2 };
 const RESOLVED_EXTENSION_DECISIONS = new Set(['extended', 'let_walk', 'tagged']);
+const ROSTER_COUNTING_STATUSES = new Set(['active', 'injured_reserve']);
+const ROSTER_LIMIT_PHASES = new Set([
+  'offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason', 'regular', 'playoffs',
+]);
 
 const canonicalId = (value) => value == null ? null : String(value);
 const playerId = (player) => player?.id ?? player?.prospectId ?? null;
@@ -393,10 +399,119 @@ export function createContractDecisionQueueBuilder({ buildPresentation = buildPl
 
 export const buildContractDecisionQueue = createContractDecisionQueueBuilder();
 
+function rosterLimitForDecision(league) {
+  const phase = league?.phase;
+  if (!ROSTER_LIMIT_PHASES.has(phase)) return null;
+  // Starting the season has a distinct, authoritative 53-player gate in the
+  // advance handler even though preseason transactions retain the 90-player
+  // offseason limit.
+  return phase === 'preseason'
+    ? Constants.ROSTER_LIMITS.REGULAR_SEASON
+    : getRosterLimitForPhase(phase);
+}
+
+function resolveRoster(roster, league, team, diagnostics) {
+  const leaguePlayers = Array.isArray(league?.players) ? league.players : [];
+  const byId = new Map(leaguePlayers.map((entry) => [canonicalId(playerId(entry)), entry]));
+  const seen = new Set();
+  const players = [];
+  for (const entry of roster) {
+    const resolved = entry && typeof entry === 'object' ? entry : byId.get(canonicalId(entry));
+    const id = playerId(resolved) ?? (typeof entry !== 'object' ? entry : null);
+    if (!resolved || playerId(resolved) == null) {
+      diagnostics.push({ playerId: id ?? null, reason: 'Unresolved player ID' });
+      continue;
+    }
+    const key = canonicalId(playerId(resolved));
+    if (seen.has(key)) {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Duplicate roster reference' });
+      continue;
+    }
+    seen.add(key);
+    if (!sameId(resolved.teamId, team.id)) {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Player not owned by supplied team' });
+      continue;
+    }
+    if (!resolved.status && resolved.onIR !== true) {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Roster-counting status unavailable' });
+      continue;
+    }
+    const status = resolved.onIR === true ? 'injured_reserve' : resolved.status;
+    if (!ROSTER_COUNTING_STATUSES.has(status)) {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Status does not count toward constrained roster' });
+      continue;
+    }
+    players.push(resolved);
+  }
+  return players;
+}
+
+export function buildRosterLimitContext({ roster, team, league } = {}) {
+  const diagnostics = [];
+  const limit = rosterLimitForDecision(league);
+  if (!Array.isArray(roster)) diagnostics.push({ playerId: null, reason: 'Roster unavailable' });
+  if (!team || team.id == null) diagnostics.push({ playerId: null, reason: 'Supplied team unavailable' });
+  if (limit == null || !Number.isFinite(limit)) diagnostics.push({ playerId: null, reason: 'Roster limit authority unavailable' });
+  if (diagnostics.length || !Array.isArray(roster) || !team || team.id == null || limit == null) {
+    return { currentCount: null, limit: limit ?? null, requiredMoves: 0, overLimit: false, availableData: false, diagnostics };
+  }
+  const players = resolveRoster(roster, league, team, diagnostics);
+  const currentCount = players.length;
+  const requiredMoves = Math.max(0, currentCount - limit);
+  diagnostics.sort((a, b) => compareIds(a.playerId, b.playerId) || a.reason.localeCompare(b.reason));
+  return { currentCount, limit, requiredMoves, overLimit: requiredMoves > 0, availableData: true, diagnostics };
+}
+
+export function createRosterCutdownDecisionQueueBuilder({ buildPresentation = buildPlayerDecisionPresentation } = {}) {
+  return function buildRosterCutdownDecisionQueue(input = {}) {
+    const context = buildRosterLimitContext(input);
+    if (!context.overLimit) return { items: [], diagnostics: context.diagnostics };
+    const candidateDiagnostics = [];
+    const players = resolveRoster(input.roster, input.league, input.team, candidateDiagnostics);
+    const positionCounts = new Map();
+    const presented = players.map((player) => {
+      const presentation = buildPresentation({ player, team: input.team, league: input.league ?? {} });
+      const position = presentation?.identity?.position ?? player?.pos ?? player?.position ?? '—';
+      positionCounts.set(position, (positionCounts.get(position) ?? 0) + 1);
+      return { player, presentation, position };
+    });
+    const candidates = presented.map(({ player, presentation, position }) => {
+      const role = presentation?.role?.label ?? null;
+      const replacementDifficulty = presentation?.replacement?.label ?? null;
+      const reasons = [];
+      if (['Starter', 'Backup', 'Reserve'].includes(role)) reasons.push(`${role} role`);
+      reasons.push(`${positionCounts.get(position)} ${position}s currently rostered`);
+      if (replacementDifficulty) reasons.push(`${replacementDifficulty} replacement difficulty`);
+      return {
+        playerId: playerId(player), position, reasons,
+        availableData: { role: role != null, replacementDifficulty: replacementDifficulty != null },
+        role: role ?? null, replacementDifficulty,
+      };
+    }).sort((a, b) => String(a.position).localeCompare(String(b.position)) || compareIds(a.playerId, b.playerId));
+    const critical = input.league?.phase === 'preseason';
+    const teamId = input.team.id;
+    return {
+      items: [{
+        id: `roster_cutdown:${canonicalId(teamId)}`, category: 'roster_cutdown', severity: critical ? 'critical' : 'high',
+        subject: { type: 'team', teamId }, title: 'Roster cutdown required',
+        primaryReason: `${context.requiredMoves} roster move${context.requiredMoves === 1 ? '' : 's'} required`,
+        reasons: [`${context.currentCount} / ${context.limit} players`], destination: { view: 'Roster / Depth' },
+        stableSortKey: `${critical ? 0 : 1}:roster_cutdown:${canonicalId(teamId)}`,
+        rosterConstraint: { currentCount: context.currentCount, limit: context.limit, requiredMoves: context.requiredMoves, candidates },
+        availableData: context.availableData,
+      }],
+      diagnostics: context.diagnostics,
+    };
+  };
+}
+
+export const buildRosterCutdownDecisionQueue = createRosterCutdownDecisionQueueBuilder();
+
 function compareCombinedItems(left, right) {
   const severity = (SEVERITY_RANK[left.severity] ?? 3) - (SEVERITY_RANK[right.severity] ?? 3);
   if (severity) return severity;
-  const category = (left.category === 'availability' ? 0 : 1) - (right.category === 'availability' ? 0 : 1);
+  const categoryRank = { availability: 0, roster_cutdown: 1, contract: 2 };
+  const category = (categoryRank[left.category] ?? 3) - (categoryRank[right.category] ?? 3);
   if (category) return category;
   return String(left.stableSortKey ?? '').localeCompare(String(right.stableSortKey ?? ''), 'en', { numeric: true })
     || compareIds(left.subject?.playerId, right.subject?.playerId);
@@ -412,7 +527,8 @@ export function createGMDecisionQueueBuilder({ buildPresentation = buildPlayerDe
     };
     const availability = createAvailabilityDecisionQueueBuilder({ buildPresentation: presentOnce })(input);
     const contracts = createContractDecisionQueueBuilder({ buildPresentation: presentOnce })(input);
-    const diagnostics = [...availability.diagnostics, ...contracts.diagnostics];
+    const rosterCutdown = createRosterCutdownDecisionQueueBuilder({ buildPresentation: presentOnce })(input);
+    const diagnostics = [...availability.diagnostics, ...contracts.diagnostics, ...rosterCutdown.diagnostics];
     const diagnosticKeys = new Set(diagnostics.map((entry) => `${canonicalId(entry.playerId) ?? 'unresolved'}:${entry.reason}`));
     const addDiagnostic = (id, reason) => {
       const key = `${canonicalId(id) ?? 'unresolved'}:${reason}`;
@@ -422,7 +538,7 @@ export function createGMDecisionQueueBuilder({ buildPresentation = buildPlayerDe
       }
     };
     const exactIds = new Set();
-    const candidates = [...availability.items, ...contracts.items].filter((item) => {
+    const candidates = [...availability.items, ...contracts.items, ...rosterCutdown.items].filter((item) => {
       if (exactIds.has(item.id)) {
         addDiagnostic(item.subject?.playerId, 'Duplicate decision item ID');
         return false;
@@ -432,12 +548,13 @@ export function createGMDecisionQueueBuilder({ buildPresentation = buildPlayerDe
     });
     const byPlayer = new Map();
     candidates.forEach((item) => {
+      if (item.subject?.type !== 'player') return;
       const key = canonicalId(item.subject?.playerId);
       const bucket = byPlayer.get(key) ?? [];
       bucket.push(item);
       byPlayer.set(key, bucket);
     });
-    const items = [];
+    const items = candidates.filter((item) => item.subject?.type !== 'player');
     for (const [id, bucket] of byPlayer) {
       const availabilityItem = bucket.find((item) => item.category === 'availability');
       const contractItem = bucket.find((item) => item.category === 'contract');

--- a/src/core/gmDecisionQueue.js
+++ b/src/core/gmDecisionQueue.js
@@ -20,7 +20,6 @@ const RETENTION_RECOMMENDATION_RANK = {
 const RETENTION_ROLE_RANK = { core_starter: 0, starter: 1, rotation: 2, depth: 3 };
 const MARKET_RANK = { high: 0, medium: 1, low: 2 };
 const RESOLVED_EXTENSION_DECISIONS = new Set(['extended', 'let_walk', 'tagged']);
-const ROSTER_COUNTING_STATUSES = new Set(['active', 'injured_reserve']);
 const ROSTER_LIMIT_PHASES = new Set([
   'offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason', 'regular', 'playoffs',
 ]);
@@ -432,14 +431,14 @@ function resolveRoster(roster, league, team, diagnostics) {
       diagnostics.push({ playerId: playerId(resolved), reason: 'Player not owned by supplied team' });
       continue;
     }
-    if (!resolved.status && resolved.onIR !== true) {
-      diagnostics.push({ playerId: playerId(resolved), reason: 'Roster-counting status unavailable' });
+    if (resolved.status === 'free_agent') {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Recorded free agent excluded from roster count' });
       continue;
     }
-    const status = resolved.onIR === true ? 'injured_reserve' : resolved.status;
-    if (!ROSTER_COUNTING_STATUSES.has(status)) {
-      diagnostics.push({ playerId: playerId(resolved), reason: 'Status does not count toward constrained roster' });
-      continue;
+    if (resolved.status == null || String(resolved.status).trim() === '') {
+      diagnostics.push({ playerId: playerId(resolved), reason: 'Roster status unavailable; counted by team ownership' });
+    } else if (!['active', 'injured_reserve'].includes(resolved.status)) {
+      diagnostics.push({ playerId: playerId(resolved), reason: `Nonstandard roster status "${String(resolved.status)}"; counted by team ownership` });
     }
     players.push(resolved);
   }

--- a/src/ui/components/GMDecisionCenter.jsx
+++ b/src/ui/components/GMDecisionCenter.jsx
@@ -13,6 +13,7 @@ function isDepthChartDestination(destination) {
 
 function routeFor(destination) {
   if (destination?.view === 'Contract Center') return 'Contract Center';
+  if (destination?.view === 'Roster / Depth') return 'Team:Roster / Depth';
   return isDepthChartDestination(destination) ? 'Team:Roster / Depth' : 'Team:Injuries';
 }
 
@@ -47,6 +48,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
           const severity = SEVERITY_STYLES[item.severity] ?? SEVERITY_STYLES.medium;
           const depthChart = isDepthChartDestination(item.destination);
           const contractReview = item.destination?.view === 'Contract Center';
+          const rosterReview = item.destination?.view === 'Roster / Depth';
           return (
             <article
               key={item.id}
@@ -62,6 +64,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
                     {item.severity === 'critical' ? '⚠ ' : ''}{severity.label}
                   </span>
                   <div style={{ marginTop: 5, fontSize: 'var(--text-sm)', fontWeight: 800 }}>{item.title}</div>
+                  {item.rosterConstraint ? <div style={{ marginTop: 3, fontSize: 'var(--text-sm)', fontWeight: 900 }}>{item.rosterConstraint.currentCount} / {item.rosterConstraint.limit}</div> : null}
                   {item.primaryReason ?? item.reasons?.[0] ? <div style={{ marginTop: 3, color: 'var(--text-muted)', fontSize: 'var(--text-xs)', overflowWrap: 'anywhere' }}>• {item.primaryReason ?? item.reasons?.[0]}</div> : null}
                 </div>
                 <button
@@ -70,7 +73,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
                   onClick={() => onNavigate?.(routeFor(item.destination))}
                   style={{ flex: '0 0 auto' }}
                 >
-                  {depthChart ? 'Review Depth Chart' : contractReview ? 'Review Re-Sign' : 'Review'}
+                  {rosterReview ? 'Review Roster' : depthChart ? 'Review Depth Chart' : contractReview ? 'Review Re-Sign' : 'Review'}
                 </button>
               </div>
             </article>

--- a/src/ui/components/__tests__/GMDecisionCenter.test.jsx
+++ b/src/ui/components/__tests__/GMDecisionCenter.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import GMDecisionCenter from '../GMDecisionCenter.jsx';
+import { normalizeManagementDestination } from '../../utils/managementScreenRouting.js';
 
 const { buildQueue } = vi.hoisted(() => ({ buildQueue: vi.fn() }));
 
@@ -87,6 +88,24 @@ describe('GMDecisionCenter', () => {
     expect(onNavigate).toHaveBeenNthCalledWith(1, 'Team:Roster / Depth');
     expect(onNavigate).toHaveBeenNthCalledWith(2, 'Team:Injuries');
     expect(onNavigate).toHaveBeenNthCalledWith(3, 'Contract Center');
+  });
+
+  it('renders one compact roster constraint and uses existing roster navigation', () => {
+    const onNavigate = vi.fn();
+    buildQueue.mockReturnValue({
+      items: [{ ...item('roster_cutdown:10', 'critical', 'Roster / Depth'), title: 'Roster cutdown required', primaryReason: '4 roster moves required', rosterConstraint: { currentCount: 57, limit: 53, requiredMoves: 4 } }],
+      diagnostics: [],
+    });
+    render(<GMDecisionCenter league={league} onNavigate={onNavigate} />);
+    expect(screen.getAllByTestId('gm-decision-item')).toHaveLength(1);
+    expect(screen.getByText('57 / 53')).toBeTruthy();
+    expect(screen.getByText('• 4 roster moves required')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Review Roster' }));
+    expect(onNavigate).toHaveBeenCalledWith('Team:Roster / Depth');
+    expect(normalizeManagementDestination(onNavigate.mock.calls[0][0])).toMatchObject({
+      tab: 'Team',
+      teamSection: 'Roster / Depth',
+    });
   });
 
   it('renders primaryReason rather than relying on the final reasons element', () => {

--- a/src/ui/utils/managementScreenRouting.test.js
+++ b/src/ui/utils/managementScreenRouting.test.js
@@ -51,6 +51,10 @@ describe("normalizeManagementDestination", () => {
   });
 
   it("supports team command center section deep links with default", () => {
+    expect(normalizeManagementDestination("Team:Roster / Depth")).toMatchObject({
+      tab: "Team",
+      teamSection: "Roster / Depth",
+    });
     expect(normalizeManagementDestination("Team:Contracts")).toMatchObject({
       tab: "Team",
       teamSection: "Contracts",


### PR DESCRIPTION
### Motivation

- Introduce a deterministic, read-only roster cutdown checker that surfaces when a team is over an authoritative roster limit and expose a compact team-level decision in the GM queue and UI.

### Description

- Added a new docs audit `docs/gm-decision-queue-roster-cutdown-v3-audit.md` describing authorities and design decisions for roster cutdown behavior.
- Implemented roster cutdown logic in `src/core/gmDecisionQueue.js`, including `rosterLimitForDecision`, `resolveRoster`, `buildRosterLimitContext`, and a `createRosterCutdownDecisionQueueBuilder` with exported `buildRosterCutdownDecisionQueue`, plus constants to control counting statuses and valid phases.
- Integrated roster cutdown into the combined GM queue builder so team-level `roster_cutdown` items are produced, bypass player overlap buckets, share the presentation cache, and are ordered between availability and contract categories via an updated category ranking.
- Updated UI in `src/ui/components/GMDecisionCenter.jsx` to show compact roster constraint counts on the decision card, route `Roster / Depth` destinations to the existing `Team:Roster / Depth` management view, and adjust button labels to `Review Roster`.
- Added/updated tests and small routing normalization expectation to support the new destination and UI behavior.

### Testing

- Ran unit tests with `vitest` covering updated behavior; relevant test files exercised include `src/core/__tests__/gmDecisionQueue.test.js`, `src/ui/components/__tests__/GMDecisionCenter.test.jsx`, and `src/ui/utils/managementScreenRouting.test.js`, and all assertions in those tests succeeded.
- Verified that the new `buildRosterLimitContext` and `buildRosterCutdownDecisionQueue` behaviors are covered by new tests that assert correct severity, candidate composition, diagnostics, deduplication, and presentation caching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80b050aba0832d8b9676bed71e4051)