### PR TITLE
fix: honor depth-chart order in canonical rich simulation

### DIFF
--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -110,4 +110,110 @@ describe('simulateRichGame', () => {
     const two = simulateRichGame(buildPayload(455));
     expect(one).toEqual(two);
   });
+
+  it('gives the depth-1 QB the team passing work even when a higher-OVR backup is listed first', () => {
+    const payload = buildPayload(1684);
+    payload.homePlayers = [
+      { id: 'h-qb-backup', name: 'Backup QB', pos: 'QB', ovr: 95, depthOrder: 2 },
+      { id: 'h-qb-starter', name: 'Starter QB', pos: 'QB', ovr: 60, depthOrder: 1 },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    const starter = summary.boxScore.home['h-qb-starter'];
+    const backup = summary.boxScore.home['h-qb-backup'];
+    const teamAtt = summary.teamStats.home.passAtt;
+
+    expect(teamAtt).toBeGreaterThan(10);
+    expect(starter?.stats.passAtt).toBe(teamAtt);
+    expect(backup?.stats.passAtt ?? 0).toBe(0);
+    expect(starter.stats.passAtt / teamAtt).toBeGreaterThanOrEqual(0.95);
+  });
+
+  it('shifts WR targets toward the depth-1 receiver when the chart is swapped', () => {
+    const seeds = [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222];
+
+    const receptionsFor = (wr1Depth: number, wr2Depth: number) => {
+      let wr1 = 0;
+      let wr2 = 0;
+      for (const seed of seeds) {
+        const payload = buildPayload(seed);
+        payload.homePlayers = payload.homePlayers.map((player) => {
+          if (player.id === 'h-wr1') return { ...player, ovr: 70, depthOrder: wr1Depth };
+          if (player.id === 'h-wr2') return { ...player, ovr: 90, depthOrder: wr2Depth };
+          return { ...player, depthOrder: 1 };
+        });
+        const summary = simulateRichGame(payload);
+        wr1 += Number(summary.boxScore.home['h-wr1']?.stats.receptions ?? 0);
+        wr2 += Number(summary.boxScore.home['h-wr2']?.stats.receptions ?? 0);
+      }
+      return { wr1, wr2 };
+    };
+
+    const starterFirst = receptionsFor(1, 2);
+    const swapped = receptionsFor(2, 1);
+
+    expect(starterFirst.wr1).toBeGreaterThan(starterFirst.wr2);
+    expect(swapped.wr2).toBeGreaterThan(swapped.wr1);
+    expect(starterFirst.wr1).toBeGreaterThan(swapped.wr1);
+  });
+
+  it('stays deterministic when the same depth chart is reused', () => {
+    const payload = buildPayload(1702);
+    payload.homePlayers = payload.homePlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+    payload.awayPlayers = payload.awayPlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(payload));
+  });
+
+  it('keeps payload order for old saves that have no depthOrder', () => {
+    const payload = buildPayload(1911);
+    payload.homePlayers = [
+      { id: 'h-qb-listed-first', name: 'Listed First QB', pos: 'QB', ovr: 60 },
+      { id: 'h-qb-listed-second', name: 'Listed Second QB', pos: 'QB', ovr: 95 },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    expect(summary.boxScore.home['h-qb-listed-first']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
+    expect(summary.boxScore.home['h-qb-listed-second']?.stats.passAtt ?? 0).toBe(0);
+  });
+
+  it('keeps scoring and volume ranges stable across a 16-seed matrix', () => {
+    const seeds = Array.from({ length: 16 }, (_, i) => 1400 + i);
+    const rows = seeds.map((seed) => {
+      const summary = simulateRichGame(buildPayload(seed));
+      return {
+        points: summary.homeScore + summary.awayScore,
+        passAtt: summary.teamStats.home.passAtt + summary.teamStats.away.passAtt,
+        rushAtt: summary.teamStats.home.rushAtt + summary.teamStats.away.rushAtt,
+        passYd: summary.teamStats.home.passYd + summary.teamStats.away.passYd,
+        rushYd: summary.teamStats.home.rushYd + summary.teamStats.away.rushYd,
+        sacks: (summary.teamStats.home.sacksAllowed ?? 0) + (summary.teamStats.away.sacksAllowed ?? 0),
+        ints: (summary.teamStats.home.interceptions ?? 0) + (summary.teamStats.away.interceptions ?? 0),
+      };
+    });
+    const mean = (key) => rows.reduce((sum, row) => sum + row[key], 0) / rows.length;
+
+    // Pre-change 24-seed balanced snapshot (no depth) sat near 53 points, 62 pass att, 53 rush att.
+    // These bands prove depth weighting did not rebalance the engine.
+    expect(mean('points')).toBeGreaterThan(35);
+    expect(mean('points')).toBeLessThan(75);
+    expect(mean('passAtt')).toBeGreaterThan(45);
+    expect(mean('passAtt')).toBeLessThan(85);
+    expect(mean('rushAtt')).toBeGreaterThan(35);
+    expect(mean('rushAtt')).toBeLessThan(75);
+    expect(mean('passYd')).toBeGreaterThan(250);
+    expect(mean('passYd')).toBeLessThan(700);
+    expect(mean('rushYd')).toBeGreaterThan(100);
+    expect(mean('rushYd')).toBeLessThan(400);
+    expect(mean('sacks')).toBeLessThan(6);
+    expect(mean('ints')).toBeLessThan(4);
+  });
 });

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -201,4 +201,31 @@ describe('weekSimulationBridge', () => {
 
     expect(mapped.shutoutFloorApplied).toEqual({ home: false, away: true });
   });
+
+  it('prefers the depth-1 QB over a higher-OVR backup when aggregating unit ratings', () => {
+    const wrs = Array.from({ length: 12 }, (_, i) => ({
+      id: 100 + i,
+      name: `WR${i}`,
+      pos: 'WR',
+      ovr: 50,
+      depthOrder: 1,
+    }));
+    const starterUnits = aggregateTeamUnitsFromRoster([
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1 },
+      ...wrs,
+    ] as any);
+    const backupUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 1 },
+      ...wrs,
+    ] as any);
+    const mixedUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 2 },
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1 },
+      ...wrs,
+    ] as any);
+
+    expect(mixedUnits.offense.throwAccuracyShort).toBe(starterUnits.offense.throwAccuracyShort);
+    expect(mixedUnits.offense.throwPower).toBe(starterUnits.offense.throwPower);
+    expect(mixedUnits.offense.throwAccuracyShort).not.toBe(backupUnits.offense.throwAccuracyShort);
+  });
 });

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -23,6 +23,11 @@ export interface SimPlayerRef {
   ovr?: number;
   /** Optional morale score (0–100). Absent on old saves; treated as 0 modifier. */
   morale?: number;
+  /**
+   * 1-based depth-chart order (1 = starter). Absent/invalid on old saves;
+   * those players keep payload insertion order and receive no starter boost.
+   */
+  depthOrder?: number | null;
 }
 
 export interface TeamStatLine {
@@ -163,6 +168,33 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+/** 1-based depth order, or 9999 when the player has no chart assignment. */
+function resolveSimDepthOrder(player: { depthOrder?: number | null }): number {
+  const n = Number(player?.depthOrder);
+  return Number.isFinite(n) && n > 0 ? n : 9999;
+}
+
+/** Legacy starter weights from playExecution.pickStarterWeighted (x2.2 / x1.3). */
+function depthUsageMultiplier(player: SimPlayerRef): number {
+  const order = resolveSimDepthOrder(player);
+  if (order === 1) return 2.2;
+  if (order === 2) return 1.3;
+  return 1;
+}
+
+function compareSimPlayersByDepth(a: SimPlayerRef, b: SimPlayerRef): number {
+  const aOrder = resolveSimDepthOrder(a);
+  const bOrder = resolveSimDepthOrder(b);
+  const aHas = aOrder !== 9999;
+  const bHas = bOrder !== 9999;
+  // Old saves without depthOrder keep payload insertion order (no OVR-invented starter).
+  if (!aHas && !bHas) return 0;
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  const ovrDelta = Number(b?.ovr ?? 70) - Number(a?.ovr ?? 70);
+  if (ovrDelta !== 0) return ovrDelta;
+  return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+}
+
 // Rough offense-vs-defense edge (~[-50,50]) used to scale two-point success odds.
 function offenseScoreEdge(offense: AttributesV2, defense: AttributesV2): number {
   const off = ((offense.throwAccuracyShort ?? 50) + (offense.routeRunning ?? 50) + (offense.passBlockStrength ?? 50)) / 3;
@@ -271,7 +303,7 @@ function defaultPlayers(teamId: number, side: 'home' | 'away'): SimPlayerRef[] {
 
 function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number): SimPlayerRef | null {
   if (!players.length) return null;
-  const idx = chooseWeightedIndex(players.map((player) => weight(player)), rng);
+  const idx = chooseWeightedIndex(players.map((player) => Math.max(1, weight(player) * depthUsageMultiplier(player))), rng);
   return players[idx] ?? players[0] ?? null;
 }
 
@@ -290,7 +322,7 @@ function chooseWeightedIndex(weights: number[], rng: () => number): number {
 function distributeTotal(total: number, contributors: SimPlayerRef[], rng: () => number, weightFn: (p: SimPlayerRef, idx: number) => number): number[] {
   const allocations = new Array(contributors.length).fill(0);
   if (contributors.length === 0 || total <= 0) return allocations;
-  const weights = contributors.map(weightFn);
+  const weights = contributors.map((player, idx) => Math.max(0, weightFn(player, idx) * depthUsageMultiplier(player)));
   for (let i = 0; i < total; i += 1) {
     const idx = chooseWeightedIndex(weights, rng);
     allocations[idx] += 1;
@@ -345,8 +377,12 @@ function pushDigest(
 
 export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const rng = makeRng(payload.seed ?? 1);
-  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home')).map((p) => ({ ...p, id: String(p.id) }));
-  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away')).map((p) => ({ ...p, id: String(p.id) }));
+  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home'))
+    .map((p) => ({ ...p, id: String(p.id) }))
+    .sort(compareSimPlayersByDepth);
+  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away'))
+    .map((p) => ({ ...p, id: String(p.id) }))
+    .sort(compareSimPlayersByDepth);
 
   // Per-game offensive "form" (hot/cold day). Sum of three rng draws approximates
   // a normal distribution; scaled to a meaningful success-input swing so favorites

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -18,7 +18,14 @@ export interface AggregatedTeamUnits {
   migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }>;
 }
 
+function resolveRosterDepthOrder(player: Player): number {
+  const n = Number(player?.depthOrder ?? player?.depthChart?.order);
+  return Number.isFinite(n) && n > 0 ? n : 9999;
+}
+
 function stablePlayerSort(a: Player, b: Player): number {
+  const depthDelta = resolveRosterDepthOrder(a) - resolveRosterDepthOrder(b);
+  if (depthDelta !== 0) return depthDelta;
   const ovrDelta = Number(b?.ovr ?? b?.ratings?.overall ?? b?.ratings?.ovr ?? 0)
     - Number(a?.ovr ?? a?.ratings?.overall ?? a?.ratings?.ovr ?? 0);
   if (ovrDelta !== 0) return ovrDelta;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4722,6 +4722,9 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         // old saves → 0 modifier. Without this the morale sim modifier (#1591)
         // silently scored 0 for every player.
         morale: player.morale,
+        // depthOrder is 1-based (1 = starter). Missing on old saves → rich sim
+        // keeps payload insertion order and does not invent a starter boost.
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
       })),
       awayPlayers: awayRoster.map((player) => ({
         id: player.id,
@@ -4729,6 +4732,7 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         pos: player.pos,
         ovr: player.ovr ?? player?.ratings?.overall ?? player?.ratings?.ovr ?? 70,
         morale: player.morale,
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
       })),
       seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
       weather: 'clear',


### PR DESCRIPTION
## Baseline

Branched from current `main` `fbcae557afda54961601396499c93c5c1b13c287` (merge of [#1761](https://github.com/rbcati/FootballGMSim/pull/1761)). [#1758](https://github.com/rbcati/FootballGMSim/pull/1758) is also on this SHA.

## Audit lanes

Four independent lanes reported before this PR was chosen:

| Lane | Verdict |
| --- | --- |
| 1 Game Book / mobile | Six stacked identity layers still live after #1758. First useful score ~3313px at 390px. Data authority is already single (`buildGameBookPresentation`). Strong next UX PR, not this one. |
| 2 Weekly decision → sim | Canonical Advance Week is rich sim. Probe: depth-1 95-OVR QB threw 0; depth-2 60-OVR took the work. `SimPlayerRef` had no depth field. Unit aggregation sorted OVR-only. This is a correctness defect. |
| 3 Durability | 10-season seed 1684 still heap-OOM in season 6 on HEAD. Invariants clean through season 5. Next durability slice is view-state history cap, not `worker.js`. Not this PR. |
| 4 Entity / clickability | EntityLink still LeagueHub-only. TeamHub schedule shape bug. Not this PR. |

## Candidate scorecard

Weighted score = items 1–4 doubled. Higher is better. Regression Risk 10 = low risk.

| Track | Vis | Depth | Wk | Lev | Trust | Conf | Test | Risk↓ | Rev | Diff | Wtd |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Sim fidelity (depth order) | 8 | 10 | 9 | 9 | 10 | 7 | 7 | 6 | 8 | 10 | **120** |
| Game Book Mobile V2 | 9 | 3 | 10 | 6 | 7 | 9 | 9 | 8 | 9 | 4 | 102 |
| Entity drill-down V2 | 7 | 4 | 8 | 8 | 6 | 8 | 8 | 7 | 6 | 5 | 94 |
| Long-save durability V3 | 2 | 2 | 1 | 9 | 8 | 4 | 7 | 5 | 5 | 6 | 63 |

## Selected track

**Weekly Decision → Canonical Simulation Fidelity — wire existing `depthOrder` into rich-sim player selection and unit aggregation.**

This is not a missing feature. Depth chart already persists via `applyDepthChartToPlayers` (`depthOrder` + `depthChart.order`). Legacy `driveEngine` already sorts by it. Canonical Advance Week ignored it, so weekly GM depth decisions did not change who got the work.

## Runner-up and why deferred

**Game Book Mobile V2.** Highest player-visible UX win (3–4 back buttons, score repeated ~5×). It does not change football outcomes. Depth-order wiring does. Easy-to-implement must not win.

## Authority reused

- Roster depth: existing `player.depthOrder` / `player.depthChart.order` (1-based).
- Starter usage weights: legacy `playExecution.pickStarterWeighted` (`×2.2` / `×1.3`).
- One QB workload authority: `allocatePlayers` still assigns all `passAtt` to `qb[0]`. After this PR, `qb[0]` is the depth-1 QB when a chart exists.
- No second presentation layer, no save-schema field, no new RNG source.

## Root cause

`simulateRichGame` sorted/weighted by OVR and payload order only. `weekSimulationBridge.pickUnitPlayers` sorted OVR-only. The worker matchup payload never passed `depthOrder`. A user-set starter listed after a higher-OVR backup did not start.

## Implementation

1. `src/worker/worker.js` — pass `depthOrder` on `homePlayers` / `awayPlayers`.
2. `src/core/sim/richGameSimulator.ts` — resolve/sort/weight by depth; missing/invalid order → 9999, multiplier 1, **payload insertion order preserved** (no OVR-invented starter).
3. `src/core/sim/weekSimulationBridge.ts` — `stablePlayerSort` prefers depth, then the previous OVR/id fallback (this file already sorted by OVR).

## Files changed

- `src/core/sim/richGameSimulator.ts`
- `src/core/sim/weekSimulationBridge.ts`
- `src/worker/worker.js`
- `src/core/__tests__/richGameSimulator.test.ts`
- `src/core/__tests__/weekSimulationBridge.test.ts`

## Tests and outcomes

| Check | Result |
| --- | --- |
| `vitest` `richGameSimulator` + `weekSimulationBridge` | 19/19 pass |
| Related sim files that existed in this checkout | 33/33 pass |
| Full `npm run test:unit` | 5917 pass; 1 fail: `gameBookMobileDensity` `globSync is not a function` — pre-existing, this branch does not touch Game Book JSX |
| `npx --package typescript tsc -p tsconfig.sim.json` | pass (`npm run check:sim-types` cannot find `tsc` because `typescript` is not a package dependency) |
| `npm run build` | pass |
| `check:netlify-rules` | pass |
| `check:netlify-cli-build` production | pass |
| `check:netlify-cli-build:preview` | pass |
| `check:netlify-parity` | **blocked** — sandbox Node is v20.20.1, `netlify.toml` requires 22 |
| Browser E2E | **not executed** |
| Playwright weekly/mobile | **not executed** (no UI change) |

### 24-seed distribution (seeds 1100–1123)

`balanced_nodepth` after == before exactly (old-save degrade):

- points 53.333 (37–70), homeWin 0.583
- passAtt 62.125, rushAtt 52.958, passYd 455.25, rushYd 233.375
- sacks 1.417, ints 0.208
- wr1Tgt 5.583 / wr2Tgt 5.583

`balanced_depth` after: **same team volume and scores**; WHO changed:

- wr1Tgt 5.583 → 6.792
- wr2Tgt 5.583 → 4.25
- wr1Yd 55.083 → 66.375
- wr2Yd 55.333 → 39.667

`gap7_nodepth` homeWin 0.833 unchanged.

The inverted-QB case is covered by the new unit test (60-OVR depth-1 listed second gets 100% of `passAtt`).

## Browser evidence

Not applicable. This PR does not change rendered UI. No claim of visual or E2E coverage.

## Non-goals (deliberate)

- No injury-availability filter (injured stars still play)
- No prep-checklist / `hasTracking`
- No pregame decision snapshot / Game Book prep archive
- No Game Book chrome collapse
- No EntityLink rollout
- No Watch Game engine unification (watched games still use legacy `simulateBatch`)
- No success-math rebalance, no extra RNG, no save-schema change
- No `worker.js` refactor beyond passing `depthOrder` on the existing player payload

## Remaining limitations

- Watch Game still uses the legacy engine, so a watched user game can still disagree with Advance Week box scores.
- Injury / holdout / practice-squad availability is still not applied in rich sim (`isAvailableForGameDay` remains holdouts-only).
- Depth-3+ players share the same `×1` multiplier (legacy `pickStarterWeighted` did the same).
- Unit-aggregation fillers still prefer a depth-2 QB over unassigned WRs. Live depth charts assign WR order, so this is an incomplete-chart edge case, not the starter-QB bug.
- The 16-seed range-band test is a coarse safety net. The 24-seed before/after snapshot is the real volume-stability proof and is not checked into the repo.
