### PR TITLE
fix: scope rich-sim starter weighting to authoritative depth-chart row (preserve row identity)

### DIFF
--- a/src/core/__tests__/depth-chart.test.js
+++ b/src/core/__tests__/depth-chart.test.js
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings } from '../depthChart.js';
+import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings, getScrimmageDepthAssignment } from '../depthChart.js';
 
 describe('depth chart auto population', () => {
+  it('accepts only eligible non-special row identity as scrimmage authority', () => {
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'WR', order: 1 } }, 'OFFENSE')).toEqual({ rowKey: 'WR', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'RS', order: 1 } }, 'OFFENSE')).toBeNull();
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'QB', order: 1 } }, 'OFFENSE')).toBeNull();
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthOrder: 1 }, 'OFFENSE')).toBeNull();
+  });
   it('assigns eligible players into position rooms and preserves manual order', () => {
     const players = [
       { id: 1, pos: 'QB', ovr: 88, teamId: 1, status: 'active' },

--- a/src/core/__tests__/depth-chart.test.js
+++ b/src/core/__tests__/depth-chart.test.js
@@ -4,6 +4,8 @@ import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings, getScrimm
 describe('depth chart auto population', () => {
   it('accepts only eligible non-special row identity as scrimmage authority', () => {
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'WR', order: 1 } }, 'OFFENSE')).toEqual({ rowKey: 'WR', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'WR', secondaryPositions: ['RB'], depthChart: { rowKey: 'RB', order: 1 } }, 'OFFENSE')).toEqual({ rowKey: 'RB', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'CB', positions: ['CB', 'S'], depthChart: { rowKey: 'S', order: 1 } }, 'DEFENSE')).toEqual({ rowKey: 'S', order: 1 });
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'RS', order: 1 } }, 'OFFENSE')).toBeNull();
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'QB', order: 1 } }, 'OFFENSE')).toBeNull();
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthOrder: 1 }, 'OFFENSE')).toBeNull();

--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -159,6 +159,37 @@ describe('simulateRichGame', () => {
   });
 
   it.each([
+    ['RB rushing', 'WR', ['RB'], 'RB', 'rushAtt'],
+    ['S defense', 'CB', ['S'], 'S', 'tackles'],
+  ])('honors a legitimate secondary-position %s assignment', (_label, pos, secondaryPositions, rowKey, stat) => {
+    let assignedTotal = 0;
+    let invalidTotal = 0;
+    for (const seed of [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222]) {
+      const payload = buildPayload(seed);
+      const candidate = { id: 'secondary-starter', name: 'Secondary Starter', pos, secondaryPositions, ovr: 75, depthOrder: 1, depthRowKey: rowKey };
+      payload.homePlayers = [candidate, ...payload.homePlayers];
+      const assigned = simulateRichGame(payload);
+      const invalidPayload = structuredClone(payload);
+      invalidPayload.homePlayers[0].depthRowKey = 'UNKNOWN';
+      const invalid = simulateRichGame(invalidPayload);
+      assignedTotal += Number(assigned.boxScore.home['secondary-starter']?.stats[stat] ?? 0);
+      invalidTotal += Number(invalid.boxScore.home['secondary-starter']?.stats[stat] ?? 0);
+    }
+    expect(assignedTotal).toBeGreaterThan(invalidTotal);
+  });
+
+  it('does not turn a secondary-position player assigned RS1 into scrimmage starter authority', () => {
+    const payload = buildPayload(2111);
+    payload.homePlayers.unshift({
+      id: 'secondary-returner', name: 'Secondary Returner', pos: 'WR', secondaryPositions: ['RB'],
+      ovr: 90, depthOrder: 1, depthRowKey: 'RS',
+    });
+    const invalid = structuredClone(payload);
+    invalid.homePlayers[0].depthRowKey = 'UNKNOWN';
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(invalid));
+  });
+
+  it.each([
     ['WR receiving', 'WR', 'h-wr1', 'h-wr2', 'receptions'],
     ['RB rushing', 'RB', 'h-rb1', 'h-rb2', 'rushAtt'],
     ['CB defense', 'CB', 'h-cb1', 'h-cb2', 'tackles'],

--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -110,4 +110,148 @@ describe('simulateRichGame', () => {
     const two = simulateRichGame(buildPayload(455));
     expect(one).toEqual(two);
   });
+
+  it('gives the depth-1 QB the team passing work even when a higher-OVR backup is listed first', () => {
+    const payload = buildPayload(1684);
+    payload.homePlayers = [
+      { id: 'h-qb-backup', name: 'Backup QB', pos: 'QB', ovr: 95, depthOrder: 2, depthRowKey: 'QB' },
+      { id: 'h-qb-starter', name: 'Starter QB', pos: 'QB', ovr: 60, depthOrder: 1, depthRowKey: 'QB' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    const starter = summary.boxScore.home['h-qb-starter'];
+    const backup = summary.boxScore.home['h-qb-backup'];
+    const teamAtt = summary.teamStats.home.passAtt;
+
+    expect(teamAtt).toBeGreaterThan(10);
+    expect(starter?.stats.passAtt).toBe(teamAtt);
+    expect(backup?.stats.passAtt ?? 0).toBe(0);
+    expect(starter.stats.passAtt / teamAtt).toBeGreaterThanOrEqual(0.95);
+  });
+
+  it('shifts WR targets toward the depth-1 receiver when the chart is swapped', () => {
+    const seeds = [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222];
+
+    const receptionsFor = (wr1Depth: number, wr2Depth: number) => {
+      let wr1 = 0;
+      let wr2 = 0;
+      for (const seed of seeds) {
+        const payload = buildPayload(seed);
+        payload.homePlayers = payload.homePlayers.map((player) => {
+          if (player.id === 'h-wr1') return { ...player, ovr: 70, depthOrder: wr1Depth, depthRowKey: 'WR' };
+          if (player.id === 'h-wr2') return { ...player, ovr: 90, depthOrder: wr2Depth, depthRowKey: 'WR' };
+          return player;
+        });
+        const summary = simulateRichGame(payload);
+        wr1 += Number(summary.boxScore.home['h-wr1']?.stats.receptions ?? 0);
+        wr2 += Number(summary.boxScore.home['h-wr2']?.stats.receptions ?? 0);
+      }
+      return { wr1, wr2 };
+    };
+
+    const starterFirst = receptionsFor(1, 2);
+    const swapped = receptionsFor(2, 1);
+
+    expect(starterFirst.wr1).toBeGreaterThan(starterFirst.wr2);
+    expect(swapped.wr2).toBeGreaterThan(swapped.wr1);
+    expect(starterFirst.wr1).toBeGreaterThan(swapped.wr1);
+  });
+
+  it.each([
+    ['WR receiving', 'WR', 'h-wr1', 'h-wr2', 'receptions'],
+    ['RB rushing', 'RB', 'h-rb1', 'h-rb2', 'rushAtt'],
+    ['CB defense', 'CB', 'h-cb1', 'h-cb2', 'tackles'],
+  ])('does not leak RS1 into %s workload', (_label, rowKey, rsId, starterId, stat) => {
+    const payload = buildPayload(2111);
+    const template = payload.homePlayers.find((player) => player.id === rsId)!;
+    payload.homePlayers = [
+      ...payload.homePlayers.filter((player) => player.id !== rsId && player.id !== starterId),
+      { ...template, id: rsId, ovr: 95, depthOrder: 1, depthRowKey: 'RS' },
+      { ...template, id: starterId, ovr: 60, depthOrder: 1, depthRowKey: rowKey },
+    ];
+    const rsSummary = simulateRichGame(payload);
+    const invalidPayload = structuredClone(payload);
+    invalidPayload.homePlayers = invalidPayload.homePlayers.map((player) => player.id === rsId
+      ? { ...player, depthRowKey: 'UNKNOWN' }
+      : player);
+    const invalidSummary = simulateRichGame(invalidPayload);
+
+    expect(rsSummary.boxScore.home[rsId]?.stats[stat] ?? 0)
+      .toBe(invalidSummary.boxScore.home[rsId]?.stats[stat] ?? 0);
+    expect(rsSummary).toEqual(simulateRichGame(payload));
+  });
+
+  it('treats legacy flattened and special-team/invalid rows identically for scrimmage weighting', () => {
+    const payload = buildPayload(2222);
+    payload.homePlayers = [
+      { id: 'legacy', name: 'Legacy WR', pos: 'WR', ovr: 95, depthOrder: 1 },
+      { id: 'k-row', name: 'K Row WR', pos: 'WR', ovr: 95, depthOrder: 1, depthRowKey: 'K' },
+      { id: 'p-row', name: 'P Row WR', pos: 'WR', ovr: 95, depthOrder: 1, depthRowKey: 'P' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'WR'),
+    ];
+    const summary = simulateRichGame(payload);
+    const invalid = structuredClone(payload);
+    invalid.homePlayers = invalid.homePlayers.map((player) => ({ ...player, depthRowKey: 'UNKNOWN' }));
+    expect(summary).toEqual(simulateRichGame(invalid));
+  });
+
+  it('stays deterministic when the same depth chart is reused', () => {
+    const payload = buildPayload(1702);
+    payload.homePlayers = payload.homePlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+    payload.awayPlayers = payload.awayPlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(payload));
+  });
+
+  it('keeps payload order for old saves that have no depthOrder', () => {
+    const payload = buildPayload(1911);
+    payload.homePlayers = [
+      { id: 'h-qb-listed-first', name: 'Listed First QB', pos: 'QB', ovr: 60 },
+      { id: 'h-qb-listed-second', name: 'Listed Second QB', pos: 'QB', ovr: 95 },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    expect(summary.boxScore.home['h-qb-listed-first']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
+    expect(summary.boxScore.home['h-qb-listed-second']?.stats.passAtt ?? 0).toBe(0);
+  });
+
+  it('keeps scoring and volume ranges stable across a 16-seed matrix', () => {
+    const seeds = Array.from({ length: 16 }, (_, i) => 1400 + i);
+    const rows = seeds.map((seed) => {
+      const summary = simulateRichGame(buildPayload(seed));
+      return {
+        points: summary.homeScore + summary.awayScore,
+        passAtt: summary.teamStats.home.passAtt + summary.teamStats.away.passAtt,
+        rushAtt: summary.teamStats.home.rushAtt + summary.teamStats.away.rushAtt,
+        passYd: summary.teamStats.home.passYd + summary.teamStats.away.passYd,
+        rushYd: summary.teamStats.home.rushYd + summary.teamStats.away.rushYd,
+        sacks: (summary.teamStats.home.sacksAllowed ?? 0) + (summary.teamStats.away.sacksAllowed ?? 0),
+        ints: (summary.teamStats.home.interceptions ?? 0) + (summary.teamStats.away.interceptions ?? 0),
+      };
+    });
+    const mean = (key) => rows.reduce((sum, row) => sum + row[key], 0) / rows.length;
+
+    // Pre-change 24-seed balanced snapshot (no depth) sat near 53 points, 62 pass att, 53 rush att.
+    // These bands prove depth weighting did not rebalance the engine.
+    expect(mean('points')).toBeGreaterThan(35);
+    expect(mean('points')).toBeLessThan(75);
+    expect(mean('passAtt')).toBeGreaterThan(45);
+    expect(mean('passAtt')).toBeLessThan(85);
+    expect(mean('rushAtt')).toBeGreaterThan(35);
+    expect(mean('rushAtt')).toBeLessThan(75);
+    expect(mean('passYd')).toBeGreaterThan(250);
+    expect(mean('passYd')).toBeLessThan(700);
+    expect(mean('rushYd')).toBeGreaterThan(100);
+    expect(mean('rushYd')).toBeLessThan(400);
+    expect(mean('sacks')).toBeLessThan(6);
+    expect(mean('ints')).toBeLessThan(4);
+  });
 });

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -201,4 +201,46 @@ describe('weekSimulationBridge', () => {
 
     expect(mapped.shutoutFloorApplied).toEqual({ home: false, away: true });
   });
+
+  it('prefers the depth-1 QB over a higher-OVR backup when aggregating unit ratings', () => {
+    const wrs = Array.from({ length: 12 }, (_, i) => ({
+      id: 100 + i,
+      name: `WR${i}`,
+      pos: 'WR',
+      ovr: 50,
+      depthOrder: 1,
+    }));
+    const starterUnits = aggregateTeamUnitsFromRoster([
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+    const backupUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+    const mixedUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 2, depthChart: { rowKey: 'QB', order: 2 } },
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+
+    expect(mixedUnits.offense.throwAccuracyShort).toBe(starterUnits.offense.throwAccuracyShort);
+    expect(mixedUnits.offense.throwPower).toBe(starterUnits.offense.throwPower);
+    expect(mixedUnits.offense.throwAccuracyShort).not.toBe(backupUnits.offense.throwAccuracyShort);
+  });
+
+  it('does not let an RS assignment affect scrimmage unit aggregation', () => {
+    const roster = [
+      { id: 1, name: 'Returner', pos: 'WR', ovr: 92, depthOrder: 1, depthChart: { rowKey: 'RS', order: 1 } },
+      { id: 2, name: 'WR starter', pos: 'WR', ovr: 65, depthOrder: 1, depthChart: { rowKey: 'WR', order: 1 } },
+      { id: 3, name: 'QB', pos: 'QB', ovr: 75, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+    ] as any;
+    const withReturnRow = aggregateTeamUnitsFromRoster(roster);
+    const withoutReturnRow = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 1
+      ? { ...player, depthOrder: undefined, depthChart: undefined }
+      : player));
+
+    expect(withReturnRow.offense).toEqual(withoutReturnRow.offense);
+    expect(withReturnRow.defense).toEqual(withoutReturnRow.defense);
+  });
 });

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -243,4 +243,32 @@ describe('weekSimulationBridge', () => {
     expect(withReturnRow.offense).toEqual(withoutReturnRow.offense);
     expect(withReturnRow.defense).toEqual(withoutReturnRow.defense);
   });
+
+  it('retains an incompatible scrimmage-row penalty without granting starter authority', () => {
+    const roster = [
+      { id: 1, name: 'Natural QB', pos: 'QB', ovr: 72, depthChart: { rowKey: 'QB', order: 2 } },
+      { id: 2, name: 'Out-of-position WR', pos: 'WR', ovr: 90, depthChart: { rowKey: 'QB', order: 1 } },
+      { id: 3, name: 'Natural WR', pos: 'WR', ovr: 70 },
+    ] as any;
+    const starterOrder = aggregateTeamUnitsFromRoster(roster);
+    const depthOrderNine = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 2
+      ? { ...player, depthChart: { rowKey: 'QB', order: 9 } }
+      : player));
+    const unassigned = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 2
+      ? { ...player, depthChart: undefined }
+      : player));
+
+    expect(starterOrder.offense).toEqual(depthOrderNine.offense);
+    expect(starterOrder.offense.routeRunning).toBeLessThan(unassigned.offense.routeRunning);
+  });
+
+  it('preserves natural behavior and evaluates an eligible secondary-position row', () => {
+    const natural = { id: 1, name: 'Hybrid', pos: 'WR', secondaryPositions: ['RB'], ovr: 82 } as any;
+    const unassigned = aggregateTeamUnitsFromRoster([natural]);
+    const unknown = aggregateTeamUnitsFromRoster([{ ...natural, depthChart: { rowKey: 'UNKNOWN', order: 1 } }] as any);
+    const assignedRb = aggregateTeamUnitsFromRoster([{ ...natural, depthChart: { rowKey: 'RB', order: 1 } }] as any);
+
+    expect(unknown.offense).toEqual(unassigned.offense);
+    expect(assignedRb.offense.routeRunning).toBeLessThan(unassigned.offense.routeRunning);
+  });
 });

--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -22,6 +22,17 @@ export function getDepthRows() {
   return DEPTH_CHART_ROWS;
 }
 
+/** Return a usable scrimmage assignment without treating legacy/special rows as generic depth. */
+export function getScrimmageDepthAssignment(player, group = null) {
+  const rowKey = String(player?.depthChart?.rowKey ?? '');
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  const order = Number(player?.depthChart?.order);
+  const pos = String(player?.pos ?? '').toUpperCase();
+  if (!row || row.group === 'SPECIAL' || (group && row.group !== group)) return null;
+  if (!row.match.includes(pos) || !Number.isFinite(order) || order <= 0) return null;
+  return { rowKey: row.key, order };
+}
+
 function rowForPosition(pos, preferredRowKey = null) {
   if (preferredRowKey) {
     const preferred = DEPTH_CHART_ROWS.find((r) => r.key === preferredRowKey);

--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -22,17 +22,6 @@ export function getDepthRows() {
   return DEPTH_CHART_ROWS;
 }
 
-/** Return a usable scrimmage assignment without treating legacy/special rows as generic depth. */
-export function getScrimmageDepthAssignment(player, group = null) {
-  const rowKey = String(player?.depthChart?.rowKey ?? '');
-  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
-  const order = Number(player?.depthChart?.order);
-  const pos = String(player?.pos ?? '').toUpperCase();
-  if (!row || row.group === 'SPECIAL' || (group && row.group !== group)) return null;
-  if (!row.match.includes(pos) || !Number.isFinite(order) || order <= 0) return null;
-  return { rowKey: row.key, order };
-}
-
 function rowForPosition(pos, preferredRowKey = null) {
   if (preferredRowKey) {
     const preferred = DEPTH_CHART_ROWS.find((r) => r.key === preferredRowKey);
@@ -41,10 +30,33 @@ function rowForPosition(pos, preferredRowKey = null) {
   return DEPTH_CHART_ROWS.find((r) => r.match.includes(pos));
 }
 
-function getPlayerFallbackPositions(player = {}) {
+export function getPlayerFallbackPositions(player = {}) {
   if (Array.isArray(player?.secondaryPositions)) return player.secondaryPositions;
   if (Array.isArray(player?.positions)) return player.positions.slice(1);
   return [];
+}
+
+export function isPlayerEligibleForDepthRow(player, row) {
+  if (!row) return false;
+  const positions = [player?.pos, ...getPlayerFallbackPositions(player)]
+    .map((pos) => String(pos ?? '').toUpperCase());
+  return positions.some((pos) => row.match.includes(pos));
+}
+
+/** Existing scrimmage row identity, regardless of eligibility for starter authority. */
+export function getScrimmageDepthRow(player, group = null) {
+  const rowKey = String(player?.depthChart?.rowKey ?? '');
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  if (!row || row.group === 'SPECIAL' || (group && row.group !== group)) return null;
+  return row;
+}
+
+/** Return a position-compatible scrimmage assignment that may grant depth authority. */
+export function getScrimmageDepthAssignment(player, group = null) {
+  const row = getScrimmageDepthRow(player, group);
+  const order = Number(player?.depthChart?.order);
+  if (!row || !isPlayerEligibleForDepthRow(player, row) || !Number.isFinite(order) || order <= 0) return null;
+  return { rowKey: row.key, order };
 }
 
 function playerMatchTier(player, row) {

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -4,7 +4,7 @@ import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 import { archiveGameStats } from '../playerSeasonStatsArchive.js';
 import { decideLateGameSequence } from '../simulation/clockManager.js';
 import { applyMoraleToEffectiveOvr } from './moraleSimModifier.js';
-import { DEPTH_CHART_ROWS } from '../depthChart.js';
+import { DEPTH_CHART_ROWS, isPlayerEligibleForDepthRow } from '../depthChart.js';
 
 export type DriveResult = 'TD' | 'FG' | 'Punt' | 'INT' | 'Fumble' | 'Downs';
 
@@ -31,6 +31,8 @@ export interface SimPlayerRef {
   depthOrder?: number | null;
   /** Authoritative row attached to depthOrder; absent legacy order is not promoted. */
   depthRowKey?: string | null;
+  secondaryPositions?: string[];
+  positions?: string[];
 }
 
 export interface TeamStatLine {
@@ -176,8 +178,7 @@ function resolveSimDepthOrder(player: SimPlayerRef, relevantRows: readonly strin
   const rowKey = String(player?.depthRowKey ?? '');
   const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
   const n = Number(player?.depthOrder);
-  const pos = String(player?.pos ?? '').toUpperCase();
-  return row && row.group !== 'SPECIAL' && relevantRows.includes(row.key) && row.match.includes(pos)
+  return row && row.group !== 'SPECIAL' && relevantRows.includes(row.key) && isPlayerEligibleForDepthRow(player, row)
     && Number.isFinite(n) && n > 0 ? n : 9999;
 }
 

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -4,6 +4,7 @@ import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 import { archiveGameStats } from '../playerSeasonStatsArchive.js';
 import { decideLateGameSequence } from '../simulation/clockManager.js';
 import { applyMoraleToEffectiveOvr } from './moraleSimModifier.js';
+import { DEPTH_CHART_ROWS } from '../depthChart.js';
 
 export type DriveResult = 'TD' | 'FG' | 'Punt' | 'INT' | 'Fumble' | 'Downs';
 
@@ -23,6 +24,13 @@ export interface SimPlayerRef {
   ovr?: number;
   /** Optional morale score (0–100). Absent on old saves; treated as 0 modifier. */
   morale?: number;
+  /**
+   * 1-based depth-chart order (1 = starter). Absent/invalid on old saves;
+   * those players keep payload insertion order and receive no starter boost.
+   */
+  depthOrder?: number | null;
+  /** Authoritative row attached to depthOrder; absent legacy order is not promoted. */
+  depthRowKey?: string | null;
 }
 
 export interface TeamStatLine {
@@ -163,6 +171,39 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+/** 1-based depth order, or 9999 when the player has no chart assignment. */
+function resolveSimDepthOrder(player: SimPlayerRef, relevantRows: readonly string[]): number {
+  const rowKey = String(player?.depthRowKey ?? '');
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  const n = Number(player?.depthOrder);
+  const pos = String(player?.pos ?? '').toUpperCase();
+  return row && row.group !== 'SPECIAL' && relevantRows.includes(row.key) && row.match.includes(pos)
+    && Number.isFinite(n) && n > 0 ? n : 9999;
+}
+
+/** Legacy starter weights from playExecution.pickStarterWeighted (x2.2 / x1.3). */
+function depthUsageMultiplier(player: SimPlayerRef, relevantRows: readonly string[]): number {
+  const order = resolveSimDepthOrder(player, relevantRows);
+  if (order === 1) return 2.2;
+  if (order === 2) return 1.3;
+  return 1;
+}
+
+function compareSimPlayersByDepth(relevantRows: readonly string[]) {
+  return (a: SimPlayerRef, b: SimPlayerRef): number => {
+    const aOrder = resolveSimDepthOrder(a, relevantRows);
+    const bOrder = resolveSimDepthOrder(b, relevantRows);
+    const aHas = aOrder !== 9999;
+    const bHas = bOrder !== 9999;
+    // Old saves without usable row identity keep payload insertion order.
+    if (!aHas && !bHas) return 0;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    const ovrDelta = Number(b?.ovr ?? 70) - Number(a?.ovr ?? 70);
+    if (ovrDelta !== 0) return ovrDelta;
+    return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+  };
+}
+
 // Rough offense-vs-defense edge (~[-50,50]) used to scale two-point success odds.
 function offenseScoreEdge(offense: AttributesV2, defense: AttributesV2): number {
   const off = ((offense.throwAccuracyShort ?? 50) + (offense.routeRunning ?? 50) + (offense.passBlockStrength ?? 50)) / 3;
@@ -269,9 +310,9 @@ function defaultPlayers(teamId: number, side: 'home' | 'away'): SimPlayerRef[] {
 }
 
 
-function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number): SimPlayerRef | null {
+function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number, relevantRows: readonly string[]): SimPlayerRef | null {
   if (!players.length) return null;
-  const idx = chooseWeightedIndex(players.map((player) => weight(player)), rng);
+  const idx = chooseWeightedIndex(players.map((player) => Math.max(1, weight(player) * depthUsageMultiplier(player, relevantRows))), rng);
   return players[idx] ?? players[0] ?? null;
 }
 
@@ -287,10 +328,10 @@ function chooseWeightedIndex(weights: number[], rng: () => number): number {
   return weights.length - 1;
 }
 
-function distributeTotal(total: number, contributors: SimPlayerRef[], rng: () => number, weightFn: (p: SimPlayerRef, idx: number) => number): number[] {
+function distributeTotal(total: number, contributors: SimPlayerRef[], rng: () => number, weightFn: (p: SimPlayerRef, idx: number) => number, relevantRows: readonly string[]): number[] {
   const allocations = new Array(contributors.length).fill(0);
   if (contributors.length === 0 || total <= 0) return allocations;
-  const weights = contributors.map(weightFn);
+  const weights = contributors.map((player, idx) => Math.max(0, weightFn(player, idx) * depthUsageMultiplier(player, relevantRows)));
   for (let i = 0; i < total; i += 1) {
     const idx = chooseWeightedIndex(weights, rng);
     allocations[idx] += 1;
@@ -345,8 +386,10 @@ function pushDigest(
 
 export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const rng = makeRng(payload.seed ?? 1);
-  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home')).map((p) => ({ ...p, id: String(p.id) }));
-  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away')).map((p) => ({ ...p, id: String(p.id) }));
+  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home'))
+    .map((p) => ({ ...p, id: String(p.id) }));
+  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away'))
+    .map((p) => ({ ...p, id: String(p.id) }));
 
   // Per-game offensive "form" (hot/cold day). Sum of three rng draws approximates
   // a normal distribution; scaled to a meaningful success-input swing so favorites
@@ -529,10 +572,10 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const playType = getPlayType(state, rng, offensePrep);
     const offensePlayers = state.possession === 'home' ? homePlayers : awayPlayers;
     const defensePlayers = state.possession === 'home' ? awayPlayers : homePlayers;
-    const target = playType === 'pass' ? pickWeightedPlayer(offensePlayers.filter((player) => ['WR', 'TE', 'RB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'WR' ? 12 : player.pos === 'TE' ? 8 : 5)) : null;
-    const defender = playType === 'pass' ? pickWeightedPlayer(defensePlayers.filter((player) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'CB' ? 10 : 6)) : null;
-    const blocker = pickWeightedPlayer(offensePlayers.filter((player) => ['OT', 'OG', 'C', 'TE', 'RB', 'QB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'QB' ? -10 : 0));
-    const rusher = pickWeightedPlayer(defensePlayers.filter((player) => ['EDGE', 'DE', 'DT', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'EDGE' ? 12 : 6));
+    const target = playType === 'pass' ? pickWeightedPlayer(offensePlayers.filter((player) => ['WR', 'TE', 'RB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'WR' ? 12 : player.pos === 'TE' ? 8 : 5), ['WR', 'TE', 'RB']) : null;
+    const defender = playType === 'pass' ? pickWeightedPlayer(defensePlayers.filter((player) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'CB' ? 10 : 6), ['CB', 'S', 'LB']) : null;
+    const blocker = pickWeightedPlayer(offensePlayers.filter((player) => ['OT', 'OG', 'C', 'TE', 'RB', 'QB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'QB' ? -10 : 0), ['OL', 'TE', 'RB', 'QB']);
+    const rusher = pickWeightedPlayer(defensePlayers.filter((player) => ['EDGE', 'DE', 'DT', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'EDGE' ? 12 : 6), ['EDGE', 'IDL', 'LB']);
     const tunedOffense = applyPrepToOffenseAttributes(offense, offensePrep, playType, state.yardLine >= 80);
     const fatigueBaseline = (stats.home.plays + stats.away.plays) / 220;
     const result = resolveMatchup(tunedOffense, defense, {
@@ -800,11 +843,11 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const awayTeamLine = buildTeamLine(stats.away);
 
   const allocatePlayers = (players: SimPlayerRef[], offense: TeamStatLine, defense: TeamStatLine, rngFn: () => number) => {
-    const qb = players.filter((p) => p.pos === 'QB');
-    const rushers = players.filter((p) => ['RB', 'QB', 'WR'].includes(p.pos));
-    const targets = players.filter((p) => ['WR', 'TE', 'RB'].includes(p.pos));
-    const sackers = players.filter((p) => ['EDGE', 'DE', 'DT', 'LB'].includes(p.pos));
-    const ballhawks = players.filter((p) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(p.pos));
+    const qb = players.filter((p) => p.pos === 'QB').sort(compareSimPlayersByDepth(['QB']));
+    const rushers = players.filter((p) => ['RB', 'QB', 'WR'].includes(p.pos)).sort(compareSimPlayersByDepth(['RB', 'QB', 'WR']));
+    const targets = players.filter((p) => ['WR', 'TE', 'RB'].includes(p.pos)).sort(compareSimPlayersByDepth(['WR', 'TE', 'RB']));
+    const sackers = players.filter((p) => ['EDGE', 'DE', 'DT', 'LB'].includes(p.pos)).sort(compareSimPlayersByDepth(['EDGE', 'IDL', 'LB']));
+    const ballhawks = players.filter((p) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(p.pos)).sort(compareSimPlayersByDepth(['CB', 'S', 'LB']));
 
     const statsById: Record<string, Record<string, number>> = {};
     const put = (id: string, patch: Record<string, number>) => {
@@ -828,8 +871,8 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const rushAttemptRemainder = Math.max(0, offense.rushAtt - Math.round(offense.rushAtt * 0.09));
     const rushYardRemainder = Math.max(0, offense.rushYd - Math.round(offense.rushYd * 0.07));
     const rushersPool = rushers.length ? rushers : [primaryQb];
-    const rushAttemptParts = distributeTotal(rushAttemptRemainder, rushersPool, rngFn, (p, idx) => (p.pos === 'RB' ? 3 : (p.pos === 'WR' ? 1.2 : 0.8)) + (p.ovr ?? 70) / 60 - idx * 0.2);
-    const rushYardParts = distributeTotal(rushYardRemainder, rushersPool, rngFn, (p) => (p.pos === 'RB' ? 2.8 : 1.1) + (p.ovr ?? 70) / 65);
+    const rushAttemptParts = distributeTotal(rushAttemptRemainder, rushersPool, rngFn, (p, idx) => (p.pos === 'RB' ? 3 : (p.pos === 'WR' ? 1.2 : 0.8)) + (p.ovr ?? 70) / 60 - idx * 0.2, ['RB', 'QB', 'WR']);
+    const rushYardParts = distributeTotal(rushYardRemainder, rushersPool, rngFn, (p) => (p.pos === 'RB' ? 2.8 : 1.1) + (p.ovr ?? 70) / 65, ['RB', 'QB', 'WR']);
     for (let i = 0; i < rushersPool.length; i += 1) {
       const pid = String(rushersPool[i].id);
       put(pid, {
@@ -840,9 +883,9 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     }
 
     const targetPool = targets.length ? targets : players.slice(0, 3);
-    const recParts = distributeTotal(offense.passComp, targetPool, rngFn, (p, idx) => (p.pos === 'WR' ? 2.5 : p.pos === 'TE' ? 1.8 : 1.3) + (p.ovr ?? 70) / 70 - idx * 0.08);
-    const recYardParts = distributeTotal(Math.max(0, offense.passYd), targetPool, rngFn, (p) => (p.pos === 'WR' ? 2.6 : p.pos === 'TE' ? 1.9 : 1.2) + (p.ovr ?? 70) / 75);
-    const recTdParts = distributeTotal(offense.passTD, targetPool, rngFn, (p) => (p.pos === 'TE' ? 1.4 : 1.8) + (p.ovr ?? 70) / 90);
+    const recParts = distributeTotal(offense.passComp, targetPool, rngFn, (p, idx) => (p.pos === 'WR' ? 2.5 : p.pos === 'TE' ? 1.8 : 1.3) + (p.ovr ?? 70) / 70 - idx * 0.08, ['WR', 'TE', 'RB']);
+    const recYardParts = distributeTotal(Math.max(0, offense.passYd), targetPool, rngFn, (p) => (p.pos === 'WR' ? 2.6 : p.pos === 'TE' ? 1.9 : 1.2) + (p.ovr ?? 70) / 75, ['WR', 'TE', 'RB']);
+    const recTdParts = distributeTotal(offense.passTD, targetPool, rngFn, (p) => (p.pos === 'TE' ? 1.4 : 1.8) + (p.ovr ?? 70) / 90, ['WR', 'TE', 'RB']);
     for (let i = 0; i < targetPool.length; i += 1) {
       const pid = String(targetPool[i].id);
       put(pid, {
@@ -855,14 +898,14 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     }
 
     const sackPool = sackers.length ? sackers : players.slice(0, 4);
-    const sackParts = distributeTotal(defense.sacksMade, sackPool, rngFn, (p) => (p.pos === 'EDGE' ? 2.8 : p.pos === 'DE' ? 2.3 : 1.5) + (p.ovr ?? 70) / 70);
+    const sackParts = distributeTotal(defense.sacksMade, sackPool, rngFn, (p) => (p.pos === 'EDGE' ? 2.8 : p.pos === 'DE' ? 2.3 : 1.5) + (p.ovr ?? 70) / 70, ['EDGE', 'IDL', 'LB']);
     for (let i = 0; i < sackPool.length; i += 1) {
       const pid = String(sackPool[i].id);
       put(pid, { sacks: (statsById[pid]?.sacks ?? 0) + sackParts[i] });
     }
 
     const intPool = ballhawks.length ? ballhawks : players.slice(0, 4);
-    const intParts = distributeTotal(defense.interceptions, intPool, rngFn, (p) => (p.pos === 'CB' || p.pos === 'S' ? 2.3 : 1.2) + (p.ovr ?? 70) / 90);
+    const intParts = distributeTotal(defense.interceptions, intPool, rngFn, (p) => (p.pos === 'CB' || p.pos === 'S' ? 2.3 : 1.2) + (p.ovr ?? 70) / 90, ['CB', 'S', 'LB']);
     for (let i = 0; i < intPool.length; i += 1) {
       const pid = String(intPool[i].id);
       put(pid, { interceptions: (statsById[pid]?.interceptions ?? 0) + intParts[i] });
@@ -871,11 +914,12 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const tacklerPool = players.filter((p) => ['LB', 'S', 'FS', 'SS', 'CB', 'EDGE', 'DE', 'DT'].includes(p.pos));
     const defensePool = tacklerPool.length ? tacklerPool : players.slice(0, 6);
     const tackleTotal = Math.max(38, Math.round(defense.plays * 0.82));
-    const tackleParts = distributeTotal(tackleTotal, defensePool, rngFn, (p) => (p.pos === 'LB' ? 2.6 : p.pos === 'S' ? 2.1 : p.pos === 'CB' ? 1.5 : 1.2) + (p.ovr ?? 70) / 80);
-    const tflParts = distributeTotal(Math.max(0, Math.round(defense.rushAtt * 0.09)), defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 2.2 : 0.7) + (p.ovr ?? 70) / 90);
-    const pdParts = distributeTotal(Math.max(0, Math.round(defense.passAtt * 0.16)), intPool, rngFn, (p) => (['CB', 'S', 'FS', 'SS'].includes(p.pos) ? 2.2 : 0.9) + (p.ovr ?? 70) / 90);
-    const ffParts = distributeTotal(defense.turnovers, defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 1.9 : 1.1) + (p.ovr ?? 70) / 90);
-    const frParts = distributeTotal(Math.max(0, defense.turnovers - defense.interceptions), defensePool, rngFn, (p) => 1 + (p.ovr ?? 70) / 100);
+    const defensiveRows = ['EDGE', 'IDL', 'LB', 'CB', 'S'];
+    const tackleParts = distributeTotal(tackleTotal, defensePool, rngFn, (p) => (p.pos === 'LB' ? 2.6 : p.pos === 'S' ? 2.1 : p.pos === 'CB' ? 1.5 : 1.2) + (p.ovr ?? 70) / 80, defensiveRows);
+    const tflParts = distributeTotal(Math.max(0, Math.round(defense.rushAtt * 0.09)), defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 2.2 : 0.7) + (p.ovr ?? 70) / 90, defensiveRows);
+    const pdParts = distributeTotal(Math.max(0, Math.round(defense.passAtt * 0.16)), intPool, rngFn, (p) => (['CB', 'S', 'FS', 'SS'].includes(p.pos) ? 2.2 : 0.9) + (p.ovr ?? 70) / 90, ['CB', 'S', 'LB']);
+    const ffParts = distributeTotal(defense.turnovers, defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 1.9 : 1.1) + (p.ovr ?? 70) / 90, defensiveRows);
+    const frParts = distributeTotal(Math.max(0, defense.turnovers - defense.interceptions), defensePool, rngFn, (p) => 1 + (p.ovr ?? 70) / 100, defensiveRows);
     for (let i = 0; i < defensePool.length; i += 1) {
       const pid = String(defensePool[i].id);
       addStats(statsById[pid] ?? (statsById[pid] = {}), {

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -2,6 +2,7 @@ import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
+import { getScrimmageDepthAssignment } from '../depthChart.js';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
   'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'routeRunning', 'separation',
@@ -18,7 +19,13 @@ export interface AggregatedTeamUnits {
   migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }>;
 }
 
-function stablePlayerSort(a: Player, b: Player): number {
+function resolveRosterDepthOrder(player: Player, group: 'OFFENSE' | 'DEFENSE'): number {
+  return getScrimmageDepthAssignment(player, group)?.order ?? 9999;
+}
+
+function stablePlayerSort(a: Player, b: Player, group: 'OFFENSE' | 'DEFENSE'): number {
+  const depthDelta = resolveRosterDepthOrder(a, group) - resolveRosterDepthOrder(b, group);
+  if (depthDelta !== 0) return depthDelta;
   const ovrDelta = Number(b?.ovr ?? b?.ratings?.overall ?? b?.ratings?.ovr ?? 0)
     - Number(a?.ovr ?? a?.ratings?.overall ?? a?.ratings?.ovr ?? 0);
   if (ovrDelta !== 0) return ovrDelta;
@@ -46,19 +53,22 @@ function pickUnitPlayers(
   roster: Array<Player & { attributesV2: AttributesV2 }>,
   priority: string[],
   targetSize = 11,
+  group: 'OFFENSE' | 'DEFENSE',
 ): Array<Player & { attributesV2: AttributesV2 }> {
   const picked: Array<Player & { attributesV2: AttributesV2 }> = [];
   for (const pos of priority) {
-    const slice = roster.filter((player) => String(player.pos ?? '').toUpperCase() === pos).sort(stablePlayerSort);
+    const slice = roster.filter((player) => String(player.pos ?? '').toUpperCase() === pos).sort((a, b) => stablePlayerSort(a, b, group));
     picked.push(...slice.slice(0, pos === 'QB' ? 1 : 3));
     if (picked.length >= targetSize) break;
   }
 
   if (picked.length < targetSize) {
     const pickedIds = new Set(picked.map((player) => String(player.id)));
+    const hasQuarterback = group === 'OFFENSE' && picked.some((player) => String(player.pos).toUpperCase() === 'QB');
     const fillers = roster
       .filter((player) => !pickedIds.has(String(player.id)))
-      .sort(stablePlayerSort)
+      .filter((player) => !hasQuarterback || String(player.pos).toUpperCase() !== 'QB')
+      .sort((a, b) => stablePlayerSort(a, b, group))
       .slice(0, targetSize - picked.length);
     picked.push(...fillers);
   }
@@ -68,27 +78,22 @@ function pickUnitPlayers(
 
 export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedTeamUnits {
   const migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }> = [];
-  const upgradedRoster = roster
-    .map((player) => {
-      const upgraded = ensureAttributesV2(player);
-      const assignedSlot = player?.depthChart?.rowKey;
-      const effective = getEffectivePlayerForRole(upgraded, assignedSlot);
-      const merged = {
-        ...upgraded,
-        attributesV2: {
-          ...upgraded.attributesV2,
-          ...(effective.attributesV2 ?? {}),
-        },
-      };
-      if (!player.attributesV2 && player.id != null) {
-        migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
-      }
-      return merged as Player & { attributesV2: AttributesV2 };
-    })
-    .sort(stablePlayerSort);
+  const upgradedRoster = roster.map((player) => {
+    const upgraded = ensureAttributesV2(player);
+    if (!player.attributesV2 && player.id != null) {
+      migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
+    }
+    return upgraded as Player & { attributesV2: AttributesV2 };
+  });
 
-  const offensePlayers = pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11);
-  const defensePlayers = pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11);
+  const forGroup = (group: 'OFFENSE' | 'DEFENSE') => upgradedRoster.map((player) => {
+    const assignment = getScrimmageDepthAssignment(player, group);
+    const effective = getEffectivePlayerForRole(player, assignment?.rowKey ?? String(player.pos ?? ''));
+    return { ...player, attributesV2: { ...player.attributesV2, ...(effective.attributesV2 ?? {}) } };
+  });
+
+  const offensePlayers = pickUnitPlayers(forGroup('OFFENSE'), OFFENSE_PRIORITY, 11, 'OFFENSE');
+  const defensePlayers = pickUnitPlayers(forGroup('DEFENSE'), DEFENSE_PRIORITY, 11, 'DEFENSE');
 
   return {
     offense: aggregateForKeys(offensePlayers, OFFENSE_KEYS),

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -2,7 +2,7 @@ import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
-import { getScrimmageDepthAssignment } from '../depthChart.js';
+import { getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
   'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'routeRunning', 'separation',
@@ -57,7 +57,10 @@ function pickUnitPlayers(
 ): Array<Player & { attributesV2: AttributesV2 }> {
   const picked: Array<Player & { attributesV2: AttributesV2 }> = [];
   for (const pos of priority) {
-    const slice = roster.filter((player) => String(player.pos ?? '').toUpperCase() === pos).sort((a, b) => stablePlayerSort(a, b, group));
+    const slice = roster.filter((player) => {
+      const assignment = getScrimmageDepthAssignment(player, group);
+      return (assignment?.rowKey ?? String(player.pos ?? '').toUpperCase()) === pos;
+    }).sort((a, b) => stablePlayerSort(a, b, group));
     picked.push(...slice.slice(0, pos === 'QB' ? 1 : 3));
     if (picked.length >= targetSize) break;
   }
@@ -87,9 +90,17 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedT
   });
 
   const forGroup = (group: 'OFFENSE' | 'DEFENSE') => upgradedRoster.map((player) => {
-    const assignment = getScrimmageDepthAssignment(player, group);
-    const effective = getEffectivePlayerForRole(player, assignment?.rowKey ?? String(player.pos ?? ''));
-    return { ...player, attributesV2: { ...player.attributesV2, ...(effective.attributesV2 ?? {}) } };
+    // Eligibility controls starter authority; row identity independently
+    // preserves canonical out-of-position effective-rating penalties.
+    const assignedRow = getScrimmageDepthRow(player, group);
+    const effective = getEffectivePlayerForRole(
+      { ...player, ...player.attributesV2 },
+      assignedRow?.key ?? String(player.pos ?? ''),
+    );
+    const attributesV2 = Object.fromEntries(
+      Object.keys(player.attributesV2).map((key) => [key, effective[key] ?? player.attributesV2[key]]),
+    ) as unknown as AttributesV2;
+    return { ...player, attributesV2 };
   });
 
   const offensePlayers = pickUnitPlayers(forGroup('OFFENSE'), OFFENSE_PRIORITY, 11, 'OFFENSE');

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -20,6 +20,8 @@ export interface Player {
   id: number;
   name: string;
   pos: string;
+  secondaryPositions?: string[];
+  positions?: string[];
   teamId?: number | null;
   age?: number;
   ovr?: number;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4726,6 +4726,8 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         // old saves keeps insertion order and cannot invent a starter boost.
         depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
         depthRowKey: player?.depthChart?.rowKey,
+        secondaryPositions: player?.secondaryPositions,
+        positions: player?.positions,
       })),
       awayPlayers: awayRoster.map((player) => ({
         id: player.id,
@@ -4735,6 +4737,8 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         morale: player.morale,
         depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
         depthRowKey: player?.depthChart?.rowKey,
+        secondaryPositions: player?.secondaryPositions,
+        positions: player?.positions,
       })),
       seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
       weather: 'clear',

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4722,6 +4722,10 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         // old saves → 0 modifier. Without this the morale sim modifier (#1591)
         // silently scored 0 for every player.
         morale: player.morale,
+        // Preserve authoritative row + order together. Missing row identity on
+        // old saves keeps insertion order and cannot invent a starter boost.
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
+        depthRowKey: player?.depthChart?.rowKey,
       })),
       awayPlayers: awayRoster.map((player) => ({
         id: player.id,
@@ -4729,6 +4733,8 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         pos: player.pos,
         ovr: player.ovr ?? player?.ratings?.overall ?? player?.ratings?.ovr ?? 70,
         morale: player.morale,
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
+        depthRowKey: player?.depthChart?.rowKey,
       })),
       seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
       weather: 'clear',


### PR DESCRIPTION
### Motivation

- Fix incorrect use of flattened `depthOrder` alone in the rich simulation so user-set depth rows (row + order) determine who receives starter workload. 
- Prevent special-team rows (K/P/RS) and legacy flattened orders from leaking starter multipliers into unrelated scrimmage roles (e.g., RS1 becoming WR1). 
- Preserve deterministic behavior and old-save fallback (no save-schema change, no new RNG, team-level volumes unchanged). 

### Description

- Reuse the canonical `DEPTH_CHART_ROWS` authority and add `getScrimmageDepthAssignment(player, group)` that returns a usable scrimmage assignment only for non-special, position-compatible rows. 
- Pass authoritative row identity into the sim payload by adding `depthRowKey` to `SimPlayerRef` and including it in the worker matchup payload (worker → sim). 
- Scope depth sorting/weighting to relevant scrimmage rows by: threading row-aware `resolveSimDepthOrder`, `depthUsageMultiplier`, `compareSimPlayersByDepth`, and applying them in `simulateRichGame` selection/aggregation paths (`pickWeightedPlayer`, `distributeTotal`, per-role sorting in `allocatePlayers`). 
- Update `weekSimulationBridge.aggregateTeamUnitsFromRoster` to use `getScrimmageDepthAssignment` so unit-aggregation honors only relevant row identity and ignores special-team rows for scrimmage units. 
- Add focused regression tests (rich-sim and bridge) covering inverted-QB authority, WR depth swaps, RS leakage into WR/RB/DEF, K/P/invalid/legacy handling, determinism, and volume stability; do not change legacy fallback behavior.

### Testing

- Ran focused unit tests: `src/core/__tests__/richGameSimulator.test.ts`, `src/core/__tests__/weekSimulationBridge.test.ts`, `src/core/__tests__/depth-chart.test.js` — all targeted tests passed. 
- Ran additional related suites and checks: targeted sim/playExecution/matchup/depthChartManager/fullSeasonSmoke/deterministic audits — those passed; `npm run check:sim-types`, `node --check src/core/depthChart.js`, `node --check src/worker/worker.js`, `npm run build`, and `npm run check:deploy` all succeeded in this environment. 
- Multi-seed distribution audit (temporary script) shows team-level distributions unchanged (example 16-seed mean snapshot: points 54.438, passAtt 67.125, rushAtt 49.750, passYd 494.250, rushYd 207.688, sacks 1.875, ints 0.125). 
- Full `npm run test:unit` executed here: most tests passed; two `engineSoak` soak tests exceeded a 30s test timeout (timed runs ~48s) and flagged timeouts (no assertion failures), recorded as a test-time warning in this environment. 

Note: I was unable to update the remote PR description from this environment because GitHub credentials are not available here; the changes and updated PR text are prepared and validated locally against the repository and test matrix described above. If you want I can retry pushing or you can copy this PR description into PR #1762.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81322af0b4832d84f1f63bda918742)