### PR TITLE
Honor depth-chart row identity and depthOrder when assigning workload and aggregating units

### DIFF
--- a/src/core/__tests__/depth-chart.test.js
+++ b/src/core/__tests__/depth-chart.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings, getScrimmageDepthAssignment } from '../depthChart.js';
+import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings, getCanonicalScrimmageAssignment, getScrimmageDepthAssignment } from '../depthChart.js';
 
 describe('depth chart auto population', () => {
   it('accepts only eligible non-special row identity as scrimmage authority', () => {
@@ -9,6 +9,9 @@ describe('depth chart auto population', () => {
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'RS', order: 1 } }, 'OFFENSE')).toBeNull();
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'QB', order: 1 } }, 'OFFENSE')).toBeNull();
     expect(getScrimmageDepthAssignment({ pos: 'WR', depthOrder: 1 }, 'OFFENSE')).toBeNull();
+    const qbAssignment = { pos: 'WR', secondaryPositions: ['QB'], depthChart: { rowKey: 'QB', order: 1 } };
+    expect(getCanonicalScrimmageAssignment(qbAssignment)).toEqual({ rowKey: 'QB', order: 1 });
+    expect(getScrimmageDepthAssignment(qbAssignment, 'DEFENSE')).toBeNull();
   });
   it('assigns eligible players into position rooms and preserves manual order', () => {
     const players = [

--- a/src/core/__tests__/depth-chart.test.js
+++ b/src/core/__tests__/depth-chart.test.js
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings } from '../depthChart.js';
+import { autoBuildDepthChart, applyDepthChartToPlayers, depthWarnings, getScrimmageDepthAssignment } from '../depthChart.js';
 
 describe('depth chart auto population', () => {
+  it('accepts only eligible non-special row identity as scrimmage authority', () => {
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'WR', order: 1 } }, 'OFFENSE')).toEqual({ rowKey: 'WR', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'WR', secondaryPositions: ['RB'], depthChart: { rowKey: 'RB', order: 1 } }, 'OFFENSE')).toEqual({ rowKey: 'RB', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'CB', positions: ['CB', 'S'], depthChart: { rowKey: 'S', order: 1 } }, 'DEFENSE')).toEqual({ rowKey: 'S', order: 1 });
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'RS', order: 1 } }, 'OFFENSE')).toBeNull();
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthChart: { rowKey: 'QB', order: 1 } }, 'OFFENSE')).toBeNull();
+    expect(getScrimmageDepthAssignment({ pos: 'WR', depthOrder: 1 }, 'OFFENSE')).toBeNull();
+  });
   it('assigns eligible players into position rooms and preserves manual order', () => {
     const players = [
       { id: 1, pos: 'QB', ovr: 88, teamId: 1, status: 'active' },

--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -110,4 +110,249 @@ describe('simulateRichGame', () => {
     const two = simulateRichGame(buildPayload(455));
     expect(one).toEqual(two);
   });
+
+  it('gives the depth-1 QB the team passing work even when a higher-OVR backup is listed first', () => {
+    const payload = buildPayload(1684);
+    payload.homePlayers = [
+      { id: 'h-qb-backup', name: 'Backup QB', pos: 'QB', ovr: 95, depthOrder: 2, depthRowKey: 'QB' },
+      { id: 'h-qb-starter', name: 'Starter QB', pos: 'QB', ovr: 60, depthOrder: 1, depthRowKey: 'QB' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    const starter = summary.boxScore.home['h-qb-starter'];
+    const backup = summary.boxScore.home['h-qb-backup'];
+    const teamAtt = summary.teamStats.home.passAtt;
+
+    expect(teamAtt).toBeGreaterThan(10);
+    expect(starter?.stats.passAtt).toBe(teamAtt);
+    expect(backup?.stats.passAtt ?? 0).toBe(0);
+    expect(starter.stats.passAtt / teamAtt).toBeGreaterThanOrEqual(0.95);
+  });
+
+  it('gives QB workload to an eligible secondary-position QB1 ahead of a natural QB2', () => {
+    const payload = buildPayload(1684);
+    payload.homePlayers = [
+      { id: 'secondary-qb1', name: 'Secondary QB1', pos: 'WR', secondaryPositions: ['QB'], ovr: 60, depthOrder: 1, depthRowKey: 'QB' },
+      { id: 'natural-qb2', name: 'Natural QB2', pos: 'QB', ovr: 95, depthOrder: 2, depthRowKey: 'QB' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    expect(summary.boxScore.home['secondary-qb1']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
+    expect(summary.boxScore.home['natural-qb2']?.stats.passAtt ?? 0).toBe(0);
+  });
+
+  it('does not make RS1 or an incompatible QB-row assignment eligible for QB workload', () => {
+    const payload = buildPayload(1702);
+    payload.homePlayers = [
+      { id: 'rs-wr', name: 'Return Specialist', pos: 'WR', ovr: 99, depthOrder: 1, depthRowKey: 'RS' },
+      { id: 'invalid-qb-row', name: 'Incompatible WR', pos: 'WR', ovr: 99, depthOrder: 1, depthRowKey: 'QB' },
+      { id: 'natural-qb', name: 'Natural QB', pos: 'QB', ovr: 60, depthOrder: 2, depthRowKey: 'QB' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB' && player.pos !== 'WR'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    expect(summary.boxScore.home['natural-qb']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
+    expect(summary.boxScore.home['rs-wr']?.stats.passAtt ?? 0).toBe(0);
+    expect(summary.boxScore.home['invalid-qb-row']?.stats.passAtt ?? 0).toBe(0);
+  });
+
+  it('shifts WR targets toward the depth-1 receiver when the chart is swapped', () => {
+    const seeds = [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222];
+
+    const receptionsFor = (wr1Depth: number, wr2Depth: number) => {
+      let wr1 = 0;
+      let wr2 = 0;
+      for (const seed of seeds) {
+        const payload = buildPayload(seed);
+        payload.homePlayers = payload.homePlayers.map((player) => {
+          if (player.id === 'h-wr1') return { ...player, ovr: 70, depthOrder: wr1Depth, depthRowKey: 'WR' };
+          if (player.id === 'h-wr2') return { ...player, ovr: 90, depthOrder: wr2Depth, depthRowKey: 'WR' };
+          return player;
+        });
+        const summary = simulateRichGame(payload);
+        wr1 += Number(summary.boxScore.home['h-wr1']?.stats.receptions ?? 0);
+        wr2 += Number(summary.boxScore.home['h-wr2']?.stats.receptions ?? 0);
+      }
+      return { wr1, wr2 };
+    };
+
+    const starterFirst = receptionsFor(1, 2);
+    const swapped = receptionsFor(2, 1);
+
+    expect(starterFirst.wr1).toBeGreaterThan(starterFirst.wr2);
+    expect(swapped.wr2).toBeGreaterThan(swapped.wr1);
+    expect(starterFirst.wr1).toBeGreaterThan(swapped.wr1);
+  });
+
+  it.each(['HB', 'FB'])('honors canonical RB alias %s as RB1 ahead of RB2', (pos) => {
+    let aliasAttempts = 0;
+    let rb2Attempts = 0;
+    for (const seed of [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222]) {
+      const payload = buildPayload(seed);
+      payload.homePlayers = [
+        { id: 'alias-rb1', name: `${pos} Starter`, pos, ovr: 70, depthOrder: 1, depthRowKey: 'RB' },
+        { id: 'natural-rb2', name: 'RB Backup', pos: 'RB', ovr: 90, depthOrder: 2, depthRowKey: 'RB' },
+        ...payload.homePlayers.filter((player) => player.pos !== 'RB'),
+      ];
+      const summary = simulateRichGame(payload);
+      aliasAttempts += Number(summary.boxScore.home['alias-rb1']?.stats.rushAtt ?? 0);
+      rb2Attempts += Number(summary.boxScore.home['natural-rb2']?.stats.rushAtt ?? 0);
+    }
+    expect(aliasAttempts).toBeGreaterThan(rb2Attempts);
+  });
+
+  it.each(['MLB', 'OLB', 'ILB'])('includes canonical LB alias %s in defensive workload', (pos) => {
+    let aliasTackles = 0;
+    let lb2Tackles = 0;
+    for (const seed of [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222]) {
+      const payload = buildPayload(seed);
+      payload.homePlayers = [
+        { id: 'alias-lb1', name: `${pos} Starter`, pos, ovr: 70, depthOrder: 1, depthRowKey: 'LB' },
+        { id: 'natural-lb2', name: 'LB Backup', pos: 'LB', ovr: 90, depthOrder: 2, depthRowKey: 'LB' },
+        ...payload.homePlayers.filter((player) => player.pos !== 'LB'),
+      ];
+      const summary = simulateRichGame(payload);
+      aliasTackles += Number(summary.boxScore.home['alias-lb1']?.stats.tackles ?? 0);
+      lb2Tackles += Number(summary.boxScore.home['natural-lb2']?.stats.tackles ?? 0);
+    }
+    expect(aliasTackles).toBeGreaterThan(lb2Tackles);
+  });
+
+  it('does not turn RS1 on an HB into RB starter authority', () => {
+    const payload = buildPayload(2111);
+    payload.homePlayers.unshift({ id: 'hb-returner', name: 'HB Returner', pos: 'HB', ovr: 90, depthOrder: 1, depthRowKey: 'RS' });
+    const invalid = structuredClone(payload);
+    invalid.homePlayers[0].depthRowKey = 'UNKNOWN';
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(invalid));
+  });
+
+  it.each([
+    ['RB rushing', 'WR', ['RB'], 'RB', 'rushAtt'],
+    ['S defense', 'CB', ['S'], 'S', 'tackles'],
+  ])('honors a legitimate secondary-position %s assignment', (_label, pos, secondaryPositions, rowKey, stat) => {
+    let assignedTotal = 0;
+    let invalidTotal = 0;
+    for (const seed of [1684, 1702, 1703, 1810, 1901, 2002, 2111, 2222]) {
+      const payload = buildPayload(seed);
+      const candidate = { id: 'secondary-starter', name: 'Secondary Starter', pos, secondaryPositions, ovr: 75, depthOrder: 1, depthRowKey: rowKey };
+      payload.homePlayers = [candidate, ...payload.homePlayers];
+      const assigned = simulateRichGame(payload);
+      const invalidPayload = structuredClone(payload);
+      invalidPayload.homePlayers[0].depthRowKey = 'UNKNOWN';
+      const invalid = simulateRichGame(invalidPayload);
+      assignedTotal += Number(assigned.boxScore.home['secondary-starter']?.stats[stat] ?? 0);
+      invalidTotal += Number(invalid.boxScore.home['secondary-starter']?.stats[stat] ?? 0);
+    }
+    expect(assignedTotal).toBeGreaterThan(invalidTotal);
+  });
+
+  it('does not turn a secondary-position player assigned RS1 into scrimmage starter authority', () => {
+    const payload = buildPayload(2111);
+    payload.homePlayers.unshift({
+      id: 'secondary-returner', name: 'Secondary Returner', pos: 'WR', secondaryPositions: ['RB'],
+      ovr: 90, depthOrder: 1, depthRowKey: 'RS',
+    });
+    const invalid = structuredClone(payload);
+    invalid.homePlayers[0].depthRowKey = 'UNKNOWN';
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(invalid));
+  });
+
+  it.each([
+    ['WR receiving', 'WR', 'h-wr1', 'h-wr2', 'receptions'],
+    ['RB rushing', 'RB', 'h-rb1', 'h-rb2', 'rushAtt'],
+    ['CB defense', 'CB', 'h-cb1', 'h-cb2', 'tackles'],
+  ])('does not leak RS1 into %s workload', (_label, rowKey, rsId, starterId, stat) => {
+    const payload = buildPayload(2111);
+    const template = payload.homePlayers.find((player) => player.id === rsId)!;
+    payload.homePlayers = [
+      ...payload.homePlayers.filter((player) => player.id !== rsId && player.id !== starterId),
+      { ...template, id: rsId, ovr: 95, depthOrder: 1, depthRowKey: 'RS' },
+      { ...template, id: starterId, ovr: 60, depthOrder: 1, depthRowKey: rowKey },
+    ];
+    const rsSummary = simulateRichGame(payload);
+    const invalidPayload = structuredClone(payload);
+    invalidPayload.homePlayers = invalidPayload.homePlayers.map((player) => player.id === rsId
+      ? { ...player, depthRowKey: 'UNKNOWN' }
+      : player);
+    const invalidSummary = simulateRichGame(invalidPayload);
+
+    expect(rsSummary.boxScore.home[rsId]?.stats[stat] ?? 0)
+      .toBe(invalidSummary.boxScore.home[rsId]?.stats[stat] ?? 0);
+    expect(rsSummary).toEqual(simulateRichGame(payload));
+  });
+
+  it('treats legacy flattened and special-team/invalid rows identically for scrimmage weighting', () => {
+    const payload = buildPayload(2222);
+    payload.homePlayers = [
+      { id: 'legacy', name: 'Legacy WR', pos: 'WR', ovr: 95, depthOrder: 1 },
+      { id: 'k-row', name: 'K Row WR', pos: 'WR', ovr: 95, depthOrder: 1, depthRowKey: 'K' },
+      { id: 'p-row', name: 'P Row WR', pos: 'WR', ovr: 95, depthOrder: 1, depthRowKey: 'P' },
+      ...payload.homePlayers.filter((player) => player.pos !== 'WR'),
+    ];
+    const summary = simulateRichGame(payload);
+    const invalid = structuredClone(payload);
+    invalid.homePlayers = invalid.homePlayers.map((player) => ({ ...player, depthRowKey: 'UNKNOWN' }));
+    expect(summary).toEqual(simulateRichGame(invalid));
+  });
+
+  it('stays deterministic when the same depth chart is reused', () => {
+    const payload = buildPayload(1702);
+    payload.homePlayers = payload.homePlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+    payload.awayPlayers = payload.awayPlayers.map((player, idx) => ({
+      ...player,
+      depthOrder: idx === 0 ? 1 : idx,
+    }));
+
+    expect(simulateRichGame(payload)).toEqual(simulateRichGame(payload));
+  });
+
+  it('keeps payload order for old saves that have no depthOrder', () => {
+    const payload = buildPayload(1911);
+    payload.homePlayers = [
+      { id: 'h-qb-listed-first', name: 'Listed First QB', pos: 'QB', ovr: 60 },
+      { id: 'h-qb-listed-second', name: 'Listed Second QB', pos: 'QB', ovr: 95 },
+      ...payload.homePlayers.filter((player) => player.pos !== 'QB'),
+    ];
+
+    const summary = simulateRichGame(payload);
+    expect(summary.boxScore.home['h-qb-listed-first']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
+    expect(summary.boxScore.home['h-qb-listed-second']?.stats.passAtt ?? 0).toBe(0);
+  });
+
+  it('keeps scoring and volume ranges stable across a 16-seed matrix', () => {
+    const seeds = Array.from({ length: 16 }, (_, i) => 1400 + i);
+    const rows = seeds.map((seed) => {
+      const summary = simulateRichGame(buildPayload(seed));
+      return {
+        points: summary.homeScore + summary.awayScore,
+        passAtt: summary.teamStats.home.passAtt + summary.teamStats.away.passAtt,
+        rushAtt: summary.teamStats.home.rushAtt + summary.teamStats.away.rushAtt,
+        passYd: summary.teamStats.home.passYd + summary.teamStats.away.passYd,
+        rushYd: summary.teamStats.home.rushYd + summary.teamStats.away.rushYd,
+        sacks: (summary.teamStats.home.sacksAllowed ?? 0) + (summary.teamStats.away.sacksAllowed ?? 0),
+        ints: (summary.teamStats.home.interceptions ?? 0) + (summary.teamStats.away.interceptions ?? 0),
+      };
+    });
+    const mean = (key) => rows.reduce((sum, row) => sum + row[key], 0) / rows.length;
+
+    // Pre-change 24-seed balanced snapshot (no depth) sat near 53 points, 62 pass att, 53 rush att.
+    // These bands prove depth weighting did not rebalance the engine.
+    expect(mean('points')).toBeGreaterThan(35);
+    expect(mean('points')).toBeLessThan(75);
+    expect(mean('passAtt')).toBeGreaterThan(45);
+    expect(mean('passAtt')).toBeLessThan(85);
+    expect(mean('rushAtt')).toBeGreaterThan(35);
+    expect(mean('rushAtt')).toBeLessThan(75);
+    expect(mean('passYd')).toBeGreaterThan(250);
+    expect(mean('passYd')).toBeLessThan(700);
+    expect(mean('rushYd')).toBeGreaterThan(100);
+    expect(mean('rushYd')).toBeLessThan(400);
+    expect(mean('sacks')).toBeLessThan(6);
+    expect(mean('ints')).toBeLessThan(4);
+  });
 });

--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -141,6 +141,9 @@ describe('simulateRichGame', () => {
     const summary = simulateRichGame(payload);
     expect(summary.boxScore.home['secondary-qb1']?.stats.passAtt).toBe(summary.teamStats.home.passAtt);
     expect(summary.boxScore.home['natural-qb2']?.stats.passAtt ?? 0).toBe(0);
+    expect(summary.boxScore.home['secondary-qb1']?.stats.targets ?? 0).toBe(0);
+    expect(summary.boxScore.home['secondary-qb1']?.stats.receptions ?? 0).toBe(0);
+    expect(summary.boxScore.home['secondary-qb1']?.stats.recYd ?? 0).toBe(0);
   });
 
   it('does not make RS1 or an incompatible QB-row assignment eligible for QB workload', () => {

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -201,4 +201,92 @@ describe('weekSimulationBridge', () => {
 
     expect(mapped.shutoutFloorApplied).toEqual({ home: false, away: true });
   });
+
+  it('prefers the depth-1 QB over a higher-OVR backup when aggregating unit ratings', () => {
+    const wrs = Array.from({ length: 12 }, (_, i) => ({
+      id: 100 + i,
+      name: `WR${i}`,
+      pos: 'WR',
+      ovr: 50,
+      depthOrder: 1,
+    }));
+    const starterUnits = aggregateTeamUnitsFromRoster([
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+    const backupUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+    const mixedUnits = aggregateTeamUnitsFromRoster([
+      { id: 2, name: 'Backup', pos: 'QB', ovr: 95, depthOrder: 2, depthChart: { rowKey: 'QB', order: 2 } },
+      { id: 1, name: 'Starter', pos: 'QB', ovr: 70, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      ...wrs,
+    ] as any);
+
+    expect(mixedUnits.offense.throwAccuracyShort).toBe(starterUnits.offense.throwAccuracyShort);
+    expect(mixedUnits.offense.throwPower).toBe(starterUnits.offense.throwPower);
+    expect(mixedUnits.offense.throwAccuracyShort).not.toBe(backupUnits.offense.throwAccuracyShort);
+  });
+
+  it('does not let an RS assignment affect scrimmage unit aggregation', () => {
+    const roster = [
+      { id: 1, name: 'Returner', pos: 'WR', ovr: 92, depthOrder: 1, depthChart: { rowKey: 'RS', order: 1 } },
+      { id: 2, name: 'WR starter', pos: 'WR', ovr: 65, depthOrder: 1, depthChart: { rowKey: 'WR', order: 1 } },
+      { id: 3, name: 'QB', pos: 'QB', ovr: 75, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+    ] as any;
+    const withReturnRow = aggregateTeamUnitsFromRoster(roster);
+    const withoutReturnRow = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 1
+      ? { ...player, depthOrder: undefined, depthChart: undefined }
+      : player));
+
+    expect(withReturnRow.offense).toEqual(withoutReturnRow.offense);
+    expect(withReturnRow.defense).toEqual(withoutReturnRow.defense);
+  });
+
+  it.each(['DT', 'NT', 'DL'])('includes an %s alias assigned to canonical IDL when other defensive rows are full', (pos) => {
+    const attributes = (passRush: number) => ({ ...mapOverallToAttributesV2(70, 0, `idl-${pos}-${passRush}`), passRush });
+    const populated = [
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `edge-${i}`, name: `EDGE${i}`, pos: 'EDGE', attributesV2: attributes(50), depthChart: { rowKey: 'EDGE', order: i + 1 } })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `lb-${i}`, name: `LB${i}`, pos: 'LB', attributesV2: attributes(50), depthChart: { rowKey: 'LB', order: i + 1 } })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `cb-${i}`, name: `CB${i}`, pos: 'CB', attributesV2: attributes(50), depthChart: { rowKey: 'CB', order: i + 1 } })),
+      ...Array.from({ length: 3 }, (_, i) => ({ id: `s-${i}`, name: `S${i}`, pos: 'S', attributesV2: attributes(50), depthChart: { rowKey: 'S', order: i + 1 } })),
+    ];
+    const lowIdl = { id: 'idl', name: 'IDL1', pos, attributesV2: attributes(20), depthChart: { rowKey: 'IDL', order: 1 } };
+    const highIdl = { ...lowIdl, attributesV2: attributes(100) };
+
+    const lowUnits = aggregateTeamUnitsFromRoster([lowIdl, ...populated] as any);
+    const highUnits = aggregateTeamUnitsFromRoster([highIdl, ...populated] as any);
+
+    expect(highUnits.defense.passRush).toBeGreaterThan(lowUnits.defense.passRush);
+    expect(highUnits.defense.pressCoverage).toBe(lowUnits.defense.pressCoverage);
+  });
+
+  it('retains an incompatible scrimmage-row penalty without granting starter authority', () => {
+    const roster = [
+      { id: 1, name: 'Natural QB', pos: 'QB', ovr: 72, depthChart: { rowKey: 'QB', order: 2 } },
+      { id: 2, name: 'Out-of-position WR', pos: 'WR', ovr: 90, depthChart: { rowKey: 'QB', order: 1 } },
+      { id: 3, name: 'Natural WR', pos: 'WR', ovr: 70 },
+    ] as any;
+    const starterOrder = aggregateTeamUnitsFromRoster(roster);
+    const depthOrderNine = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 2
+      ? { ...player, depthChart: { rowKey: 'QB', order: 9 } }
+      : player));
+    const unassigned = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 2
+      ? { ...player, depthChart: undefined }
+      : player));
+
+    expect(starterOrder.offense).toEqual(depthOrderNine.offense);
+    expect(starterOrder.offense.routeRunning).toBeLessThan(unassigned.offense.routeRunning);
+  });
+
+  it('preserves natural behavior and evaluates an eligible secondary-position row', () => {
+    const natural = { id: 1, name: 'Hybrid', pos: 'WR', secondaryPositions: ['RB'], ovr: 82 } as any;
+    const unassigned = aggregateTeamUnitsFromRoster([natural]);
+    const unknown = aggregateTeamUnitsFromRoster([{ ...natural, depthChart: { rowKey: 'UNKNOWN', order: 1 } }] as any);
+    const assignedRb = aggregateTeamUnitsFromRoster([{ ...natural, depthChart: { rowKey: 'RB', order: 1 } }] as any);
+
+    expect(unknown.offense).toEqual(unassigned.offense);
+    expect(assignedRb.offense.routeRunning).toBeLessThan(unassigned.offense.routeRunning);
+  });
 });

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -6,6 +6,7 @@ import {
   mapGameSummaryToLegacyResult,
   simulateWithOptionalNewEngine,
 } from '../sim/weekSimulationBridge.ts';
+import { applyDepthChartToPlayers } from '../depthChart.js';
 
 describe('weekSimulationBridge', () => {
   it('aggregates offense/defense units from roster players and migrates missing attributesV2', () => {
@@ -260,6 +261,49 @@ describe('weekSimulationBridge', () => {
 
     expect(highUnits.defense.passRush).toBeGreaterThan(lowUnits.defense.passRush);
     expect(highUnits.defense.pressCoverage).toBe(lowUnits.defense.pressCoverage);
+  });
+
+  it('builds an 11-player defensive unit across every canonical row without duplicates', () => {
+    const rows = [
+      ['EDGE', 'DE', 4],
+      ['IDL', 'DT', 4],
+      ['LB', 'LB', 5],
+      ['CB', 'CB', 5],
+      ['S', 'S', 3],
+    ] as const;
+    let nextId = 1;
+    const players: any[] = [];
+    const assignments: Record<string, number[]> = {};
+    for (const [rowKey, pos, count] of rows) {
+      assignments[rowKey] = [];
+      for (let order = 1; order <= count; order += 1) {
+        const player = { id: nextId, name: `${rowKey}${order}`, pos, ovr: 90 - order, teamId: 1 };
+        players.push(player);
+        assignments[rowKey].push(nextId);
+        nextId += 1;
+      }
+    }
+    const secondarySafety = { id: nextId, name: 'Secondary S1', pos: 'WR', secondaryPositions: ['S'], ovr: 95, teamId: 1 };
+    players.push(secondarySafety);
+    assignments.S.unshift(nextId);
+    const roster = applyDepthChartToPlayers(players, assignments);
+
+    const first = aggregateTeamUnitsFromRoster(roster as any);
+    const second = aggregateTeamUnitsFromRoster(roster as any);
+    const selected = first.selectedUnitPlayerIds.defense;
+    const namesById = new Map(roster.map((player) => [player.id, player.name]));
+    const selectedNames = selected.map((id) => namesById.get(id));
+
+    expect(selected).toHaveLength(11);
+    expect(new Set(selected).size).toBe(11);
+    expect(selectedNames.some((name) => name?.startsWith('EDGE'))).toBe(true);
+    expect(selectedNames.some((name) => name?.startsWith('IDL'))).toBe(true);
+    expect(selectedNames.some((name) => name?.startsWith('LB'))).toBe(true);
+    expect(selectedNames.some((name) => name?.startsWith('CB'))).toBe(true);
+    expect(selectedNames).toContain('Secondary S1');
+    expect(selectedNames.filter((name) => name?.startsWith('S') || name === 'Secondary S1')).toHaveLength(1);
+    expect(second.selectedUnitPlayerIds.defense).toEqual(selected);
+    expect(second.defense).toEqual(first.defense);
   });
 
   it('retains an incompatible scrimmage-row penalty without granting starter authority', () => {

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -306,6 +306,33 @@ describe('weekSimulationBridge', () => {
     expect(second.defense).toEqual(first.defense);
   });
 
+  it.each([
+    ['CB assigned WR1', { id: 1, name: 'CB at WR', pos: 'CB', secondaryPositions: ['WR'], depthChart: { rowKey: 'WR', order: 1 } }, 'offense', 'defense'],
+    ['WR assigned CB1', { id: 2, name: 'WR at CB', pos: 'WR', secondaryPositions: ['CB'], depthChart: { rowKey: 'CB', order: 1 } }, 'defense', 'offense'],
+  ])('keeps %s exclusively in its authoritative scrimmage unit', (_label, assigned, includedGroup, excludedGroup) => {
+    const roster = [
+      assigned,
+      { id: 10, name: 'QB', pos: 'QB', ovr: 75 },
+      { id: 11, name: 'WR', pos: 'WR', ovr: 75 },
+      { id: 12, name: 'CB', pos: 'CB', ovr: 75 },
+      { id: 13, name: 'S', pos: 'S', ovr: 75 },
+      { id: 14, name: 'LB', pos: 'LB', ovr: 75 },
+      { id: 15, name: 'DE', pos: 'DE', ovr: 75 },
+      { id: 16, name: 'DT', pos: 'DT', ovr: 75 },
+    ] as any;
+    const units = aggregateTeamUnitsFromRoster(roster);
+
+    expect(units.selectedUnitPlayerIds[includedGroup]).toContain(assigned.id);
+    expect(units.selectedUnitPlayerIds[excludedGroup]).not.toContain(assigned.id);
+  });
+
+  it('keeps natural-position fallback when no valid canonical assignment exists', () => {
+    const natural = { id: 1, name: 'Natural WR', pos: 'WR', ovr: 80 } as any;
+    const units = aggregateTeamUnitsFromRoster([natural]);
+
+    expect(units.selectedUnitPlayerIds.offense).toContain(natural.id);
+  });
+
   it('retains an incompatible scrimmage-row penalty without granting starter authority', () => {
     const roster = [
       { id: 1, name: 'Natural QB', pos: 'QB', ovr: 72, depthChart: { rowKey: 'QB', order: 2 } },

--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -30,10 +30,41 @@ function rowForPosition(pos, preferredRowKey = null) {
   return DEPTH_CHART_ROWS.find((r) => r.match.includes(pos));
 }
 
-function getPlayerFallbackPositions(player = {}) {
+export function getPlayerFallbackPositions(player = {}) {
   if (Array.isArray(player?.secondaryPositions)) return player.secondaryPositions;
   if (Array.isArray(player?.positions)) return player.positions.slice(1);
   return [];
+}
+
+export function isPlayerEligibleForDepthRow(player, row) {
+  if (!row) return false;
+  const positions = [player?.pos, ...getPlayerFallbackPositions(player)]
+    .map((pos) => String(pos ?? '').toUpperCase());
+  return positions.some((pos) => row.match.includes(pos));
+}
+
+/** Existing scrimmage row identity, regardless of eligibility for starter authority. */
+export function getScrimmageDepthRow(player, group = null) {
+  const rowKey = String(player?.depthChart?.rowKey ?? '');
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  if (!row || row.group === 'SPECIAL' || (group && row.group !== group)) return null;
+  return row;
+}
+
+/** Return a position-compatible scrimmage assignment that may grant depth authority. */
+export function getScrimmageDepthAssignment(player, group = null) {
+  const row = getScrimmageDepthRow(player, group);
+  const order = Number(player?.depthChart?.order);
+  if (!row || !isPlayerEligibleForDepthRow(player, row) || !Number.isFinite(order) || order <= 0) return null;
+  return { rowKey: row.key, order };
+}
+
+/** Canonical row used to place a player in a scrimmage unit. */
+export function getPlayerScrimmageUnitRow(player, group) {
+  const assignment = getScrimmageDepthAssignment(player, group);
+  if (assignment) return DEPTH_CHART_ROWS.find((row) => row.key === assignment.rowKey) ?? null;
+  const primaryPos = String(player?.pos ?? '').toUpperCase();
+  return DEPTH_CHART_ROWS.find((row) => row.group === group && row.match.includes(primaryPos)) ?? null;
 }
 
 function playerMatchTier(player, row) {

--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -52,17 +52,30 @@ export function getScrimmageDepthRow(player, group = null) {
 }
 
 /** Return a position-compatible scrimmage assignment that may grant depth authority. */
-export function getScrimmageDepthAssignment(player, group = null) {
-  const row = getScrimmageDepthRow(player, group);
-  const order = Number(player?.depthChart?.order);
+export function getCanonicalScrimmageAssignment(player) {
+  const rowKey = String(player?.depthChart?.rowKey ?? player?.depthRowKey ?? '');
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  const order = Number(player?.depthChart?.order ?? player?.depthOrder);
   if (!row || !isPlayerEligibleForDepthRow(player, row) || !Number.isFinite(order) || order <= 0) return null;
+  if (row.group === 'SPECIAL') return null;
   return { rowKey: row.key, order };
+}
+
+/** Return a canonical assignment only when it belongs to the requested unit. */
+export function getScrimmageDepthAssignment(player, group = null) {
+  const assignment = getCanonicalScrimmageAssignment(player);
+  if (!assignment) return null;
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === assignment.rowKey);
+  return group && row?.group !== group ? null : assignment;
 }
 
 /** Canonical row used to place a player in a scrimmage unit. */
 export function getPlayerScrimmageUnitRow(player, group) {
-  const assignment = getScrimmageDepthAssignment(player, group);
-  if (assignment) return DEPTH_CHART_ROWS.find((row) => row.key === assignment.rowKey) ?? null;
+  const assignment = getCanonicalScrimmageAssignment(player);
+  if (assignment) {
+    const row = DEPTH_CHART_ROWS.find((entry) => entry.key === assignment.rowKey) ?? null;
+    return row?.group === group ? row : null;
+  }
   const primaryPos = String(player?.pos ?? '').toUpperCase();
   return DEPTH_CHART_ROWS.find((row) => row.group === group && row.match.includes(primaryPos)) ?? null;
 }

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -4,6 +4,7 @@ import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 import { archiveGameStats } from '../playerSeasonStatsArchive.js';
 import { decideLateGameSequence } from '../simulation/clockManager.js';
 import { applyMoraleToEffectiveOvr } from './moraleSimModifier.js';
+import { DEPTH_CHART_ROWS, isPlayerEligibleForDepthRow } from '../depthChart.js';
 
 export type DriveResult = 'TD' | 'FG' | 'Punt' | 'INT' | 'Fumble' | 'Downs';
 
@@ -23,6 +24,15 @@ export interface SimPlayerRef {
   ovr?: number;
   /** Optional morale score (0–100). Absent on old saves; treated as 0 modifier. */
   morale?: number;
+  /**
+   * 1-based depth-chart order (1 = starter). Absent/invalid on old saves;
+   * those players keep payload insertion order and receive no starter boost.
+   */
+  depthOrder?: number | null;
+  /** Authoritative row attached to depthOrder; absent legacy order is not promoted. */
+  depthRowKey?: string | null;
+  secondaryPositions?: string[];
+  positions?: string[];
 }
 
 export interface TeamStatLine {
@@ -163,6 +173,76 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+/** 1-based depth order, or 9999 when the player has no chart assignment. */
+type SimWorkloadRow = (typeof DEPTH_CHART_ROWS)[number];
+type SimWorkloadCache = WeakMap<SimPlayerRef, WeakMap<readonly string[], SimWorkloadRow>>;
+type SimWorkloadPoolCache = WeakMap<SimPlayerRef[], WeakMap<readonly string[], SimPlayerRef[]>>;
+
+const QB_WORKLOAD_ROWS = ['QB'] as const;
+const RUSHING_WORKLOAD_ROWS = ['RB', 'QB', 'WR'] as const;
+const RECEIVING_WORKLOAD_ROWS = ['WR', 'TE', 'RB'] as const;
+const PASS_RUSH_WORKLOAD_ROWS = ['EDGE', 'IDL', 'LB'] as const;
+const COVERAGE_WORKLOAD_ROWS = ['CB', 'S', 'LB'] as const;
+const DEFENSIVE_WORKLOAD_ROWS = ['EDGE', 'IDL', 'LB', 'CB', 'S'] as const;
+const BLOCKING_WORKLOAD_ROWS = ['OL', 'TE', 'RB', 'QB'] as const;
+
+function resolveSimDepthOrder(player: SimPlayerRef, relevantRows: readonly string[], cache: SimWorkloadCache): number {
+  const rowKey = String(player?.depthRowKey ?? '');
+  const row = resolveSimWorkloadRow(player, relevantRows, cache);
+  const n = Number(player?.depthOrder);
+  return row?.key === rowKey
+    && Number.isFinite(n) && n > 0 ? n : 9999;
+}
+
+/** Legacy starter weights from playExecution.pickStarterWeighted (x2.2 / x1.3). */
+function depthUsageMultiplier(player: SimPlayerRef, relevantRows: readonly string[], cache: SimWorkloadCache): number {
+  const order = resolveSimDepthOrder(player, relevantRows, cache);
+  if (order === 1) return 2.2;
+  if (order === 2) return 1.3;
+  return 1;
+}
+
+function compareSimPlayersByDepth(relevantRows: readonly string[], cache: SimWorkloadCache) {
+  return (a: SimPlayerRef, b: SimPlayerRef): number => {
+    const aOrder = resolveSimDepthOrder(a, relevantRows, cache);
+    const bOrder = resolveSimDepthOrder(b, relevantRows, cache);
+    const aHas = aOrder !== 9999;
+    const bHas = bOrder !== 9999;
+    // Old saves without usable row identity keep payload insertion order.
+    if (!aHas && !bHas) return 0;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    const ovrDelta = Number(b?.ovr ?? 70) - Number(a?.ovr ?? 70);
+    if (ovrDelta !== 0) return ovrDelta;
+    return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+  };
+}
+
+/** Resolve a workload role exclusively through the canonical depth-row authority. */
+function resolveSimWorkloadRow(player: SimPlayerRef, relevantRows: readonly string[], cache: SimWorkloadCache): SimWorkloadRow | null {
+  const playerCache = cache.get(player) ?? new WeakMap<readonly string[], SimWorkloadRow>();
+  const cached = playerCache.get(relevantRows);
+  if (cached) return cached;
+  const rows = DEPTH_CHART_ROWS.filter((row) => row.group !== 'SPECIAL' && relevantRows.includes(row.key));
+  const assigned = rows.find((row) => row.key === player.depthRowKey && isPlayerEligibleForDepthRow(player, row));
+  const primaryPos = String(player.pos ?? '').toUpperCase();
+  const resolved = assigned ?? rows.find((row) => row.match.includes(primaryPos))
+    ?? rows.find((row) => isPlayerEligibleForDepthRow(player, row))
+    ?? null;
+  if (resolved) playerCache.set(relevantRows, resolved);
+  cache.set(player, playerCache);
+  return resolved;
+}
+
+function simWorkloadPool(players: SimPlayerRef[], relevantRows: readonly string[], cache: SimWorkloadCache, poolCache: SimWorkloadPoolCache): SimPlayerRef[] {
+  const cachedPools = poolCache.get(players) ?? new WeakMap<readonly string[], SimPlayerRef[]>();
+  const cached = cachedPools.get(relevantRows);
+  if (cached) return cached;
+  const pool = players.filter((player) => resolveSimWorkloadRow(player, relevantRows, cache));
+  cachedPools.set(relevantRows, pool);
+  poolCache.set(players, cachedPools);
+  return pool;
+}
+
 // Rough offense-vs-defense edge (~[-50,50]) used to scale two-point success odds.
 function offenseScoreEdge(offense: AttributesV2, defense: AttributesV2): number {
   const off = ((offense.throwAccuracyShort ?? 50) + (offense.routeRunning ?? 50) + (offense.passBlockStrength ?? 50)) / 3;
@@ -269,9 +349,9 @@ function defaultPlayers(teamId: number, side: 'home' | 'away'): SimPlayerRef[] {
 }
 
 
-function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number): SimPlayerRef | null {
+function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number, relevantRows: readonly string[], cache: SimWorkloadCache): SimPlayerRef | null {
   if (!players.length) return null;
-  const idx = chooseWeightedIndex(players.map((player) => weight(player)), rng);
+  const idx = chooseWeightedIndex(players.map((player) => Math.max(1, weight(player) * depthUsageMultiplier(player, relevantRows, cache))), rng);
   return players[idx] ?? players[0] ?? null;
 }
 
@@ -287,10 +367,10 @@ function chooseWeightedIndex(weights: number[], rng: () => number): number {
   return weights.length - 1;
 }
 
-function distributeTotal(total: number, contributors: SimPlayerRef[], rng: () => number, weightFn: (p: SimPlayerRef, idx: number) => number): number[] {
+function distributeTotal(total: number, contributors: SimPlayerRef[], rng: () => number, weightFn: (p: SimPlayerRef, idx: number) => number, relevantRows: readonly string[], cache: SimWorkloadCache): number[] {
   const allocations = new Array(contributors.length).fill(0);
   if (contributors.length === 0 || total <= 0) return allocations;
-  const weights = contributors.map(weightFn);
+  const weights = contributors.map((player, idx) => Math.max(0, weightFn(player, idx) * depthUsageMultiplier(player, relevantRows, cache)));
   for (let i = 0; i < total; i += 1) {
     const idx = chooseWeightedIndex(weights, rng);
     allocations[idx] += 1;
@@ -345,8 +425,12 @@ function pushDigest(
 
 export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const rng = makeRng(payload.seed ?? 1);
-  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home')).map((p) => ({ ...p, id: String(p.id) }));
-  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away')).map((p) => ({ ...p, id: String(p.id) }));
+  const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home'))
+    .map((p) => ({ ...p, id: String(p.id) }));
+  const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away'))
+    .map((p) => ({ ...p, id: String(p.id) }));
+  const workloadCache: SimWorkloadCache = new WeakMap();
+  const workloadPoolCache: SimWorkloadPoolCache = new WeakMap();
 
   // Per-game offensive "form" (hot/cold day). Sum of three rng draws approximates
   // a normal distribution; scaled to a meaningful success-input swing so favorites
@@ -529,10 +613,17 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const playType = getPlayType(state, rng, offensePrep);
     const offensePlayers = state.possession === 'home' ? homePlayers : awayPlayers;
     const defensePlayers = state.possession === 'home' ? awayPlayers : homePlayers;
-    const target = playType === 'pass' ? pickWeightedPlayer(offensePlayers.filter((player) => ['WR', 'TE', 'RB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'WR' ? 12 : player.pos === 'TE' ? 8 : 5)) : null;
-    const defender = playType === 'pass' ? pickWeightedPlayer(defensePlayers.filter((player) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'CB' ? 10 : 6)) : null;
-    const blocker = pickWeightedPlayer(offensePlayers.filter((player) => ['OT', 'OG', 'C', 'TE', 'RB', 'QB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'QB' ? -10 : 0));
-    const rusher = pickWeightedPlayer(defensePlayers.filter((player) => ['EDGE', 'DE', 'DT', 'LB'].includes(player.pos)), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (player.pos === 'EDGE' ? 12 : 6));
+    const targetRows = RECEIVING_WORKLOAD_ROWS;
+    const defenderRows = COVERAGE_WORKLOAD_ROWS;
+    const blockerRows = BLOCKING_WORKLOAD_ROWS;
+    const passRusherRows = PASS_RUSH_WORKLOAD_ROWS;
+    const target = playType === 'pass' ? pickWeightedPlayer(simWorkloadPool(offensePlayers, targetRows, workloadCache, workloadPoolCache), rng, (player) => {
+      const rowKey = resolveSimWorkloadRow(player, targetRows, workloadCache)?.key;
+      return applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (rowKey === 'WR' ? 12 : rowKey === 'TE' ? 8 : 5);
+    }, targetRows, workloadCache) : null;
+    const defender = playType === 'pass' ? pickWeightedPlayer(simWorkloadPool(defensePlayers, defenderRows, workloadCache, workloadPoolCache), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (resolveSimWorkloadRow(player, defenderRows, workloadCache)?.key === 'CB' ? 10 : 6), defenderRows, workloadCache) : null;
+    const blocker = pickWeightedPlayer(simWorkloadPool(offensePlayers, blockerRows, workloadCache, workloadPoolCache), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (resolveSimWorkloadRow(player, blockerRows, workloadCache)?.key === 'QB' ? -10 : 0), blockerRows, workloadCache);
+    const rusher = pickWeightedPlayer(simWorkloadPool(defensePlayers, passRusherRows, workloadCache, workloadPoolCache), rng, (player) => applyMoraleToEffectiveOvr(player.ovr ?? 70, player) + (resolveSimWorkloadRow(player, passRusherRows, workloadCache)?.key === 'EDGE' ? 12 : 6), passRusherRows, workloadCache);
     const tunedOffense = applyPrepToOffenseAttributes(offense, offensePrep, playType, state.yardLine >= 80);
     const fatigueBaseline = (stats.home.plays + stats.away.plays) / 220;
     const result = resolveMatchup(tunedOffense, defense, {
@@ -800,11 +891,17 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const awayTeamLine = buildTeamLine(stats.away);
 
   const allocatePlayers = (players: SimPlayerRef[], offense: TeamStatLine, defense: TeamStatLine, rngFn: () => number) => {
-    const qb = players.filter((p) => p.pos === 'QB');
-    const rushers = players.filter((p) => ['RB', 'QB', 'WR'].includes(p.pos));
-    const targets = players.filter((p) => ['WR', 'TE', 'RB'].includes(p.pos));
-    const sackers = players.filter((p) => ['EDGE', 'DE', 'DT', 'LB'].includes(p.pos));
-    const ballhawks = players.filter((p) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(p.pos));
+    const qbRows = QB_WORKLOAD_ROWS;
+    const rushingRows = RUSHING_WORKLOAD_ROWS;
+    const receivingRows = RECEIVING_WORKLOAD_ROWS;
+    const passRusherRows = PASS_RUSH_WORKLOAD_ROWS;
+    const coverageRows = COVERAGE_WORKLOAD_ROWS;
+    const defensiveRows = DEFENSIVE_WORKLOAD_ROWS;
+    const qb = simWorkloadPool(players, qbRows, workloadCache, workloadPoolCache).sort(compareSimPlayersByDepth(qbRows, workloadCache));
+    const rushers = simWorkloadPool(players, rushingRows, workloadCache, workloadPoolCache).sort(compareSimPlayersByDepth(rushingRows, workloadCache));
+    const targets = simWorkloadPool(players, receivingRows, workloadCache, workloadPoolCache).sort(compareSimPlayersByDepth(receivingRows, workloadCache));
+    const sackers = simWorkloadPool(players, passRusherRows, workloadCache, workloadPoolCache).sort(compareSimPlayersByDepth(passRusherRows, workloadCache));
+    const ballhawks = simWorkloadPool(players, coverageRows, workloadCache, workloadPoolCache).sort(compareSimPlayersByDepth(coverageRows, workloadCache));
 
     const statsById: Record<string, Record<string, number>> = {};
     const put = (id: string, patch: Record<string, number>) => {
@@ -828,8 +925,11 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const rushAttemptRemainder = Math.max(0, offense.rushAtt - Math.round(offense.rushAtt * 0.09));
     const rushYardRemainder = Math.max(0, offense.rushYd - Math.round(offense.rushYd * 0.07));
     const rushersPool = rushers.length ? rushers : [primaryQb];
-    const rushAttemptParts = distributeTotal(rushAttemptRemainder, rushersPool, rngFn, (p, idx) => (p.pos === 'RB' ? 3 : (p.pos === 'WR' ? 1.2 : 0.8)) + (p.ovr ?? 70) / 60 - idx * 0.2);
-    const rushYardParts = distributeTotal(rushYardRemainder, rushersPool, rngFn, (p) => (p.pos === 'RB' ? 2.8 : 1.1) + (p.ovr ?? 70) / 65);
+    const rushAttemptParts = distributeTotal(rushAttemptRemainder, rushersPool, rngFn, (p, idx) => {
+      const rowKey = resolveSimWorkloadRow(p, rushingRows, workloadCache)?.key;
+      return (rowKey === 'RB' ? 3 : rowKey === 'WR' ? 1.2 : 0.8) + (p.ovr ?? 70) / 60 - idx * 0.2;
+    }, rushingRows, workloadCache);
+    const rushYardParts = distributeTotal(rushYardRemainder, rushersPool, rngFn, (p) => (resolveSimWorkloadRow(p, rushingRows, workloadCache)?.key === 'RB' ? 2.8 : 1.1) + (p.ovr ?? 70) / 65, rushingRows, workloadCache);
     for (let i = 0; i < rushersPool.length; i += 1) {
       const pid = String(rushersPool[i].id);
       put(pid, {
@@ -840,9 +940,15 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     }
 
     const targetPool = targets.length ? targets : players.slice(0, 3);
-    const recParts = distributeTotal(offense.passComp, targetPool, rngFn, (p, idx) => (p.pos === 'WR' ? 2.5 : p.pos === 'TE' ? 1.8 : 1.3) + (p.ovr ?? 70) / 70 - idx * 0.08);
-    const recYardParts = distributeTotal(Math.max(0, offense.passYd), targetPool, rngFn, (p) => (p.pos === 'WR' ? 2.6 : p.pos === 'TE' ? 1.9 : 1.2) + (p.ovr ?? 70) / 75);
-    const recTdParts = distributeTotal(offense.passTD, targetPool, rngFn, (p) => (p.pos === 'TE' ? 1.4 : 1.8) + (p.ovr ?? 70) / 90);
+    const recParts = distributeTotal(offense.passComp, targetPool, rngFn, (p, idx) => {
+      const rowKey = resolveSimWorkloadRow(p, receivingRows, workloadCache)?.key;
+      return (rowKey === 'WR' ? 2.5 : rowKey === 'TE' ? 1.8 : 1.3) + (p.ovr ?? 70) / 70 - idx * 0.08;
+    }, receivingRows, workloadCache);
+    const recYardParts = distributeTotal(Math.max(0, offense.passYd), targetPool, rngFn, (p) => {
+      const rowKey = resolveSimWorkloadRow(p, receivingRows, workloadCache)?.key;
+      return (rowKey === 'WR' ? 2.6 : rowKey === 'TE' ? 1.9 : 1.2) + (p.ovr ?? 70) / 75;
+    }, receivingRows, workloadCache);
+    const recTdParts = distributeTotal(offense.passTD, targetPool, rngFn, (p) => (resolveSimWorkloadRow(p, receivingRows, workloadCache)?.key === 'TE' ? 1.4 : 1.8) + (p.ovr ?? 70) / 90, receivingRows, workloadCache);
     for (let i = 0; i < targetPool.length; i += 1) {
       const pid = String(targetPool[i].id);
       put(pid, {
@@ -855,27 +961,33 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     }
 
     const sackPool = sackers.length ? sackers : players.slice(0, 4);
-    const sackParts = distributeTotal(defense.sacksMade, sackPool, rngFn, (p) => (p.pos === 'EDGE' ? 2.8 : p.pos === 'DE' ? 2.3 : 1.5) + (p.ovr ?? 70) / 70);
+    const sackParts = distributeTotal(defense.sacksMade, sackPool, rngFn, (p) => {
+      const rowKey = resolveSimWorkloadRow(p, passRusherRows, workloadCache)?.key;
+      return (rowKey === 'EDGE' ? 2.8 : rowKey === 'IDL' ? 2.3 : 1.5) + (p.ovr ?? 70) / 70;
+    }, passRusherRows, workloadCache);
     for (let i = 0; i < sackPool.length; i += 1) {
       const pid = String(sackPool[i].id);
       put(pid, { sacks: (statsById[pid]?.sacks ?? 0) + sackParts[i] });
     }
 
     const intPool = ballhawks.length ? ballhawks : players.slice(0, 4);
-    const intParts = distributeTotal(defense.interceptions, intPool, rngFn, (p) => (p.pos === 'CB' || p.pos === 'S' ? 2.3 : 1.2) + (p.ovr ?? 70) / 90);
+    const intParts = distributeTotal(defense.interceptions, intPool, rngFn, (p) => (['CB', 'S'].includes(resolveSimWorkloadRow(p, coverageRows, workloadCache)?.key ?? '') ? 2.3 : 1.2) + (p.ovr ?? 70) / 90, coverageRows, workloadCache);
     for (let i = 0; i < intPool.length; i += 1) {
       const pid = String(intPool[i].id);
       put(pid, { interceptions: (statsById[pid]?.interceptions ?? 0) + intParts[i] });
     }
 
-    const tacklerPool = players.filter((p) => ['LB', 'S', 'FS', 'SS', 'CB', 'EDGE', 'DE', 'DT'].includes(p.pos));
+    const tacklerPool = simWorkloadPool(players, defensiveRows, workloadCache, workloadPoolCache);
     const defensePool = tacklerPool.length ? tacklerPool : players.slice(0, 6);
     const tackleTotal = Math.max(38, Math.round(defense.plays * 0.82));
-    const tackleParts = distributeTotal(tackleTotal, defensePool, rngFn, (p) => (p.pos === 'LB' ? 2.6 : p.pos === 'S' ? 2.1 : p.pos === 'CB' ? 1.5 : 1.2) + (p.ovr ?? 70) / 80);
-    const tflParts = distributeTotal(Math.max(0, Math.round(defense.rushAtt * 0.09)), defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 2.2 : 0.7) + (p.ovr ?? 70) / 90);
-    const pdParts = distributeTotal(Math.max(0, Math.round(defense.passAtt * 0.16)), intPool, rngFn, (p) => (['CB', 'S', 'FS', 'SS'].includes(p.pos) ? 2.2 : 0.9) + (p.ovr ?? 70) / 90);
-    const ffParts = distributeTotal(defense.turnovers, defensePool, rngFn, (p) => (['EDGE', 'DE', 'DT', 'LB'].includes(p.pos) ? 1.9 : 1.1) + (p.ovr ?? 70) / 90);
-    const frParts = distributeTotal(Math.max(0, defense.turnovers - defense.interceptions), defensePool, rngFn, (p) => 1 + (p.ovr ?? 70) / 100);
+    const tackleParts = distributeTotal(tackleTotal, defensePool, rngFn, (p) => {
+      const rowKey = resolveSimWorkloadRow(p, defensiveRows, workloadCache)?.key;
+      return (rowKey === 'LB' ? 2.6 : rowKey === 'S' ? 2.1 : rowKey === 'CB' ? 1.5 : 1.2) + (p.ovr ?? 70) / 80;
+    }, defensiveRows, workloadCache);
+    const tflParts = distributeTotal(Math.max(0, Math.round(defense.rushAtt * 0.09)), defensePool, rngFn, (p) => (['EDGE', 'IDL', 'LB'].includes(resolveSimWorkloadRow(p, defensiveRows, workloadCache)?.key ?? '') ? 2.2 : 0.7) + (p.ovr ?? 70) / 90, defensiveRows, workloadCache);
+    const pdParts = distributeTotal(Math.max(0, Math.round(defense.passAtt * 0.16)), intPool, rngFn, (p) => (['CB', 'S'].includes(resolveSimWorkloadRow(p, coverageRows, workloadCache)?.key ?? '') ? 2.2 : 0.9) + (p.ovr ?? 70) / 90, coverageRows, workloadCache);
+    const ffParts = distributeTotal(defense.turnovers, defensePool, rngFn, (p) => (['EDGE', 'IDL', 'LB'].includes(resolveSimWorkloadRow(p, defensiveRows, workloadCache)?.key ?? '') ? 1.9 : 1.1) + (p.ovr ?? 70) / 90, defensiveRows, workloadCache);
+    const frParts = distributeTotal(Math.max(0, defense.turnovers - defense.interceptions), defensePool, rngFn, (p) => 1 + (p.ovr ?? 70) / 100, defensiveRows, workloadCache);
     for (let i = 0; i < defensePool.length; i += 1) {
       const pid = String(defensePool[i].id);
       addStats(statsById[pid] ?? (statsById[pid] = {}), {

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -4,7 +4,7 @@ import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 import { archiveGameStats } from '../playerSeasonStatsArchive.js';
 import { decideLateGameSequence } from '../simulation/clockManager.js';
 import { applyMoraleToEffectiveOvr } from './moraleSimModifier.js';
-import { DEPTH_CHART_ROWS, isPlayerEligibleForDepthRow } from '../depthChart.js';
+import { DEPTH_CHART_ROWS, getCanonicalScrimmageAssignment, isPlayerEligibleForDepthRow } from '../depthChart.js';
 
 export type DriveResult = 'TD' | 'FG' | 'Punt' | 'INT' | 'Fumble' | 'Downs';
 
@@ -223,7 +223,11 @@ function resolveSimWorkloadRow(player: SimPlayerRef, relevantRows: readonly stri
   const cached = playerCache.get(relevantRows);
   if (cached) return cached;
   const rows = DEPTH_CHART_ROWS.filter((row) => row.group !== 'SPECIAL' && relevantRows.includes(row.key));
-  const assigned = rows.find((row) => row.key === player.depthRowKey && isPlayerEligibleForDepthRow(player, row));
+  const canonicalAssignment = getCanonicalScrimmageAssignment(player);
+  const assigned = canonicalAssignment
+    ? rows.find((row) => row.key === canonicalAssignment.rowKey) ?? null
+    : null;
+  if (canonicalAssignment && !assigned) return null;
   const primaryPos = String(player.pos ?? '').toUpperCase();
   const resolved = assigned ?? rows.find((row) => row.match.includes(primaryPos))
     ?? rows.find((row) => isPlayerEligibleForDepthRow(player, row))

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -3,6 +3,7 @@ import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
 import { DEPTH_CHART_ROWS, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
+import { FOOTBALL_ROSTER_CONFIG } from '../sports/footballRosterConfig.js';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
   'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'routeRunning', 'separation',
@@ -19,6 +20,7 @@ export interface AggregatedTeamUnits {
   offense: AttributesV2;
   defense: AttributesV2;
   migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }>;
+  selectedUnitPlayerIds: { offense: Array<number | string>; defense: Array<number | string> };
 }
 
 interface UnitPlayerMetadata {
@@ -33,6 +35,30 @@ function stablePlayerSort(a: Player, b: Player, metadata: (player: Player) => Un
     - Number(a?.ovr ?? a?.ratings?.overall ?? a?.ratings?.ovr ?? 0);
   if (ovrDelta !== 0) return ovrDelta;
   return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+}
+
+function buildDefensiveRowQuotas(targetSize: number): Map<string, number> {
+  const rows = DEPTH_CHART_ROWS.filter((row) => row.group === 'DEFENSE');
+  const lineRows = rows.filter((row) => row.match.includes('DL'));
+  const lineStarterCount = Number(FOOTBALL_ROSTER_CONFIG.groupConfig.DL?.starterCountExpected ?? lineRows.length);
+  const quotas = new Map(rows.map((row) => {
+    const configured = Number(FOOTBALL_ROSTER_CONFIG.groupConfig[row.key]?.starterCountExpected);
+    const count = lineRows.includes(row)
+      ? Math.max(1, Math.floor(lineStarterCount / Math.max(1, lineRows.length)))
+      : (Number.isFinite(configured) ? configured : 1);
+    return [row.key, Math.min(row.slots, count)] as const;
+  }));
+  let allocated = [...quotas.values()].reduce((sum, count) => sum + count, 0);
+  // The canonical group counts describe 12 defensive starters. The rich unit
+  // remains 11 players, so trim rotation seats from the latest rows without
+  // ever removing a canonical row entirely.
+  for (let index = rows.length - 1; allocated > targetSize && index >= 0; index -= 1) {
+    const row = rows[index];
+    const removable = Math.min((quotas.get(row.key) ?? 1) - 1, allocated - targetSize);
+    quotas.set(row.key, (quotas.get(row.key) ?? 1) - removable);
+    allocated -= removable;
+  }
+  return quotas;
 }
 
 function aggregateForKeys(players: Array<Player & { attributesV2: AttributesV2 }>, keys: Array<keyof AttributesV2>): AttributesV2 {
@@ -60,16 +86,20 @@ function pickUnitPlayers(
   metadata: (player: Player) => UnitPlayerMetadata,
 ): Array<Player & { attributesV2: AttributesV2 }> {
   const picked: Array<Player & { attributesV2: AttributesV2 }> = [];
+  const pickedIds = new Set<string>();
+  const rowQuotas = group === 'DEFENSE' ? buildDefensiveRowQuotas(targetSize) : null;
   for (const pos of priority) {
     const slice = roster.filter((player) => {
-      return metadata(player).rowKey === pos;
+      return metadata(player).rowKey === pos && !pickedIds.has(String(player.id));
     }).sort((a, b) => stablePlayerSort(a, b, metadata));
-    picked.push(...slice.slice(0, pos === 'QB' ? 1 : 3));
-    if (picked.length >= targetSize) break;
+    const rowLimit = rowQuotas?.get(pos) ?? (pos === 'QB' ? 1 : 3);
+    const selected = slice.slice(0, rowLimit);
+    picked.push(...selected);
+    selected.forEach((player) => pickedIds.add(String(player.id)));
+    if (!rowQuotas && picked.length >= targetSize) break;
   }
 
   if (picked.length < targetSize) {
-    const pickedIds = new Set(picked.map((player) => String(player.id)));
     const hasQuarterback = group === 'OFFENSE'
       && picked.some((player) => metadata(player).rowKey === 'QB');
     const fillers = roster
@@ -123,19 +153,19 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedT
 
   const offenseMetadata = metadataFor('OFFENSE');
   const defenseMetadata = metadataFor('DEFENSE');
-  const offensePlayers = applyGroupRole(
-    pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11, 'OFFENSE', offenseMetadata),
-    'OFFENSE',
-  );
-  const defensePlayers = applyGroupRole(
-    pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11, 'DEFENSE', defenseMetadata),
-    'DEFENSE',
-  );
+  const selectedOffense = pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11, 'OFFENSE', offenseMetadata);
+  const selectedDefense = pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11, 'DEFENSE', defenseMetadata);
+  const offensePlayers = applyGroupRole(selectedOffense, 'OFFENSE');
+  const defensePlayers = applyGroupRole(selectedDefense, 'DEFENSE');
 
   return {
     offense: aggregateForKeys(offensePlayers, OFFENSE_KEYS),
     defense: aggregateForKeys(defensePlayers, DEFENSE_KEYS),
     migratedPlayers,
+    selectedUnitPlayerIds: {
+      offense: selectedOffense.map((player) => player.id),
+      defense: selectedDefense.map((player) => player.id),
+    },
   };
 }
 

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -2,7 +2,7 @@ import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
-import { DEPTH_CHART_ROWS, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
+import { DEPTH_CHART_ROWS, getCanonicalScrimmageAssignment, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
 import { FOOTBALL_ROSTER_CONFIG } from '../sports/footballRosterConfig.js';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
@@ -26,6 +26,7 @@ export interface AggregatedTeamUnits {
 interface UnitPlayerMetadata {
   rowKey: string | null;
   depthOrder: number;
+  eligibleForGroup: boolean;
 }
 
 function stablePlayerSort(a: Player, b: Player, metadata: (player: Player) => UnitPlayerMetadata): number {
@@ -104,6 +105,7 @@ function pickUnitPlayers(
       && picked.some((player) => metadata(player).rowKey === 'QB');
     const fillers = roster
       .filter((player) => !pickedIds.has(String(player.id)))
+      .filter((player) => metadata(player).eligibleForGroup)
       .filter((player) => !hasQuarterback || metadata(player).rowKey !== 'QB')
       .sort((a, b) => stablePlayerSort(a, b, metadata))
       .slice(0, targetSize - picked.length);
@@ -128,9 +130,14 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedT
     return (player: Player) => {
       const cached = cache.get(player);
       if (cached) return cached;
+      const canonicalAssignment = getCanonicalScrimmageAssignment(player);
+      const canonicalRow = canonicalAssignment
+        ? DEPTH_CHART_ROWS.find((row) => row.key === canonicalAssignment.rowKey)
+        : null;
       const metadata = {
         rowKey: getPlayerScrimmageUnitRow(player, group)?.key ?? null,
         depthOrder: getScrimmageDepthAssignment(player, group)?.order ?? 9999,
+        eligibleForGroup: !canonicalRow || canonicalRow.group === group,
       };
       cache.set(player, metadata);
       return metadata;

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -2,6 +2,7 @@ import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
+import { DEPTH_CHART_ROWS, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
   'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'routeRunning', 'separation',
@@ -10,7 +11,9 @@ const OFFENSE_KEYS: Array<keyof AttributesV2> = [
 const DEFENSE_KEYS: Array<keyof AttributesV2> = ['passRush', 'pressCoverage', 'zoneCoverage'];
 
 const OFFENSE_PRIORITY = ['QB', 'WR', 'TE', 'RB', 'OL', 'LT', 'LG', 'C', 'RG', 'RT'];
-const DEFENSE_PRIORITY = ['EDGE', 'DE', 'DT', 'LB', 'CB', 'S', 'FS', 'SS'];
+const DEFENSE_PRIORITY = DEPTH_CHART_ROWS
+  .filter((row) => row.group === 'DEFENSE')
+  .map((row) => row.key);
 
 export interface AggregatedTeamUnits {
   offense: AttributesV2;
@@ -18,7 +21,14 @@ export interface AggregatedTeamUnits {
   migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }>;
 }
 
-function stablePlayerSort(a: Player, b: Player): number {
+interface UnitPlayerMetadata {
+  rowKey: string | null;
+  depthOrder: number;
+}
+
+function stablePlayerSort(a: Player, b: Player, metadata: (player: Player) => UnitPlayerMetadata): number {
+  const depthDelta = metadata(a).depthOrder - metadata(b).depthOrder;
+  if (depthDelta !== 0) return depthDelta;
   const ovrDelta = Number(b?.ovr ?? b?.ratings?.overall ?? b?.ratings?.ovr ?? 0)
     - Number(a?.ovr ?? a?.ratings?.overall ?? a?.ratings?.ovr ?? 0);
   if (ovrDelta !== 0) return ovrDelta;
@@ -46,19 +56,26 @@ function pickUnitPlayers(
   roster: Array<Player & { attributesV2: AttributesV2 }>,
   priority: string[],
   targetSize = 11,
+  group: 'OFFENSE' | 'DEFENSE',
+  metadata: (player: Player) => UnitPlayerMetadata,
 ): Array<Player & { attributesV2: AttributesV2 }> {
   const picked: Array<Player & { attributesV2: AttributesV2 }> = [];
   for (const pos of priority) {
-    const slice = roster.filter((player) => String(player.pos ?? '').toUpperCase() === pos).sort(stablePlayerSort);
+    const slice = roster.filter((player) => {
+      return metadata(player).rowKey === pos;
+    }).sort((a, b) => stablePlayerSort(a, b, metadata));
     picked.push(...slice.slice(0, pos === 'QB' ? 1 : 3));
     if (picked.length >= targetSize) break;
   }
 
   if (picked.length < targetSize) {
     const pickedIds = new Set(picked.map((player) => String(player.id)));
+    const hasQuarterback = group === 'OFFENSE'
+      && picked.some((player) => metadata(player).rowKey === 'QB');
     const fillers = roster
       .filter((player) => !pickedIds.has(String(player.id)))
-      .sort(stablePlayerSort)
+      .filter((player) => !hasQuarterback || metadata(player).rowKey !== 'QB')
+      .sort((a, b) => stablePlayerSort(a, b, metadata))
       .slice(0, targetSize - picked.length);
     picked.push(...fillers);
   }
@@ -68,27 +85,52 @@ function pickUnitPlayers(
 
 export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedTeamUnits {
   const migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }> = [];
-  const upgradedRoster = roster
-    .map((player) => {
-      const upgraded = ensureAttributesV2(player);
-      const assignedSlot = player?.depthChart?.rowKey;
-      const effective = getEffectivePlayerForRole(upgraded, assignedSlot);
-      const merged = {
-        ...upgraded,
-        attributesV2: {
-          ...upgraded.attributesV2,
-          ...(effective.attributesV2 ?? {}),
-        },
-      };
-      if (!player.attributesV2 && player.id != null) {
-        migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
-      }
-      return merged as Player & { attributesV2: AttributesV2 };
-    })
-    .sort(stablePlayerSort);
+  const upgradedRoster = roster.map((player) => {
+    const upgraded = ensureAttributesV2(player);
+    if (!player.attributesV2 && player.id != null) {
+      migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
+    }
+    return upgraded as Player & { attributesV2: AttributesV2 };
+  });
 
-  const offensePlayers = pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11);
-  const defensePlayers = pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11);
+  const metadataFor = (group: 'OFFENSE' | 'DEFENSE') => {
+    const cache = new WeakMap<Player, UnitPlayerMetadata>();
+    return (player: Player) => {
+      const cached = cache.get(player);
+      if (cached) return cached;
+      const metadata = {
+        rowKey: getPlayerScrimmageUnitRow(player, group)?.key ?? null,
+        depthOrder: getScrimmageDepthAssignment(player, group)?.order ?? 9999,
+      };
+      cache.set(player, metadata);
+      return metadata;
+    };
+  };
+
+  const applyGroupRole = (players: Array<Player & { attributesV2: AttributesV2 }>, group: 'OFFENSE' | 'DEFENSE') => players.map((player) => {
+    // Eligibility controls starter authority; row identity independently
+    // preserves canonical out-of-position effective-rating penalties.
+    const assignedRow = getScrimmageDepthRow(player, group);
+    const effective = getEffectivePlayerForRole(
+      { ...player, ...player.attributesV2 },
+      assignedRow?.key ?? String(player.pos ?? ''),
+    );
+    const attributesV2 = Object.fromEntries(
+      Object.keys(player.attributesV2).map((key) => [key, effective[key] ?? player.attributesV2[key]]),
+    ) as unknown as AttributesV2;
+    return { ...player, attributesV2 };
+  });
+
+  const offenseMetadata = metadataFor('OFFENSE');
+  const defenseMetadata = metadataFor('DEFENSE');
+  const offensePlayers = applyGroupRole(
+    pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11, 'OFFENSE', offenseMetadata),
+    'OFFENSE',
+  );
+  const defensePlayers = applyGroupRole(
+    pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11, 'DEFENSE', defenseMetadata),
+    'DEFENSE',
+  );
 
   return {
     offense: aggregateForKeys(offensePlayers, OFFENSE_KEYS),

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -20,6 +20,8 @@ export interface Player {
   id: number;
   name: string;
   pos: string;
+  secondaryPositions?: string[];
+  positions?: string[];
   teamId?: number | null;
   age?: number;
   ovr?: number;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4722,6 +4722,12 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         // old saves → 0 modifier. Without this the morale sim modifier (#1591)
         // silently scored 0 for every player.
         morale: player.morale,
+        // Preserve authoritative row + order together. Missing row identity on
+        // old saves keeps insertion order and cannot invent a starter boost.
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
+        depthRowKey: player?.depthChart?.rowKey,
+        secondaryPositions: player?.secondaryPositions,
+        positions: player?.positions,
       })),
       awayPlayers: awayRoster.map((player) => ({
         id: player.id,
@@ -4729,6 +4735,10 @@ function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
         pos: player.pos,
         ovr: player.ovr ?? player?.ratings?.overall ?? player?.ratings?.ovr ?? 70,
         morale: player.morale,
+        depthOrder: Number(player.depthOrder ?? player?.depthChart?.order) || undefined,
+        depthRowKey: player?.depthChart?.rowKey,
+        secondaryPositions: player?.secondaryPositions,
+        positions: player?.positions,
       })),
       seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
       weather: 'clear',


### PR DESCRIPTION
### Motivation

- Ensure scrimmage starter authority comes only from a position-compatible depth-chart assignment and preserve legacy behavior for payloads without depth metadata.
- Make play/skill workload and team-unit aggregation respect canonical depth rows, secondary-position eligibility, and explicit `depthOrder` without leaking special-team rows into scrimmage authority.

### Description

- Exported and added depth-chart helpers: `getPlayerFallbackPositions`, `isPlayerEligibleForDepthRow`, `getScrimmageDepthRow`, `getScrimmageDepthAssignment`, and `getPlayerScrimmageUnitRow` in `src/core/depthChart.js` to centralize eligibility and assignment logic.  
- Rich-game simulation now resolves workload pools and starter authority via canonical depth rows and `depthOrder`, introduced caches and helper functions (`resolveSimWorkloadRow`, `resolveSimDepthOrder`, `depthUsageMultiplier`, `simWorkloadPool`, `compareSimPlayersByDepth`) and threaded these into selection/allocation flows; updated `pickWeightedPlayer` and `distributeTotal` to account for depth multipliers in `src/core/sim/richGameSimulator.ts`.  
- Team-unit aggregation and player selection now consider scrimmage row identity and eligible starter authority; added metadata caching, `applyGroupRole`, and changed `pickUnitPlayers`/`stablePlayerSort` to use row/depth metadata, in `src/core/sim/weekSimulationBridge.ts`.  
- Propagated depth metadata into simulation payloads from the worker by including `depthOrder`, `depthRowKey`, `secondaryPositions`, and `positions` in `src/worker/worker.js`.  
- Type updates to `Player` to include `secondaryPositions` and `positions` in `src/types/player.ts`.  
- Added and adjusted tests that assert correct behavior around scrimmage assignment, workload routing, legacy ordering, and unit aggregation in `src/core/__tests__/depth-chart.test.js`, `richGameSimulator.test.ts`, and `weekSimulationBridge.test.ts`.

### Testing

- Ran unit tests with `vitest` including `src/core/__tests__/depth-chart.test.js`, `src/core/__tests__/richGameSimulator.test.ts`, and `src/core/__tests__/weekSimulationBridge.test.ts`, and all new and existing tests passed.  
- Verified deterministic behavior tests (repeated `simulateRichGame` runs) and a multi-seed stability matrix completed successfully.  
- Checked aggregation/unit-selection tests exercising secondary-position and special-row edge cases and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81322af0b4832d84f1f63bda918742)