### PR TITLE
Consolidate mobile Game Book presentation — single return control & BoxScore score hero

### DIFF
--- a/docs/game-book-mobile-experience-v2-audit.md
+++ b/docs/game-book-mobile-experience-v2-audit.md
@@ -1,0 +1,63 @@
+# Game Book Mobile Experience V2 audit
+
+## Baseline
+
+- Audited `main` at `5b59927d6f527ac37d6c85d9e3bfb8858206d065`, the merge commit for PR #1768.
+- The pre-change supported-game hierarchy was: `GameDetailScreen` route stack → sticky return/week/duplicate compact score → full `ScreenHeader` with a second return, repeated final metadata, and next-week action → standalone Preparation Context `SectionCard` → outer “Game Book Detail” `SectionCard` → embedded `BoxScorePanel`/`BoxScore` with a third dismiss action, canonical score hero, section tabs, and content.
+- `BoxScore` already owned the strongest score identity and Summary / Team Stats / Players / Plays presentation. `GameDetailScreen` already owned canonical resolution and preparation classification. `LeagueDashboard`/`App` owned route navigation.
+
+## Consolidation
+
+The final supported-game hierarchy is:
+
+1. compact route-owned return bar (one button);
+2. existing `BoxScore` score/matchup hero (one visible score identity);
+3. existing Game Book section tabs;
+4. existing selected section content;
+5. compact Preparation Context subsection inside Summary.
+
+The redundant full `ScreenHeader`, standalone preparation card, outer “Game Book Detail” card, sticky duplicate score, and embedded close button were removed from the supported-game composition rather than visually hidden. Standalone/non-embedded BoxScore dismiss behavior remains intact.
+
+## Authority and truthfulness
+
+- Score, matchup, W/L/tie, week, and season continue to come from the existing `buildGameBookPresentation` result consumed by `BoxScore`; no score is recalculated.
+- The one return button calls the existing `onBack` callback. No route, navigation state, or bottom-navigation ownership changed.
+- Preparation Context still comes from `buildWeeklyDecisionImpact` and the existing `classifyPreparationBullet` rules. “Not recorded” retains the original explanatory text for assistive technology; generic and no-marker fallbacks remain explicit.
+- Team abbreviations in the score hero use the existing `TeamButton`, retaining drill-down when an `onTeamSelect` callback and team ID are available.
+- Player links and their Game Book return context are unchanged.
+- The existing presentation view model continues to gate Team Stats, Players, and Plays. Score-only/limited records receive no fabricated tabs, player rows, plays, or metrics.
+
+## Files changed
+
+- `src/ui/components/GameDetailScreen.jsx`
+- `src/ui/components/GameDetailScreen.test.jsx`
+- `src/ui/components/BoxScore.jsx`
+- `src/ui/components/BoxScore.test.jsx`
+- `src/ui/components/__tests__/gameBookMobileDensity.test.jsx`
+- `src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx`
+- `src/ui/styles/app-mobile.css`
+- `src/ui/styles/style.css`
+- `tests/e2e/mobile_game_day_trust.spec.js`
+- `docs/game-book-mobile-experience-v2-audit.md`
+
+## Mobile validation
+
+The responsive implementation uses only Game Book-specific selectors, has no fixed-width content addition, and retains horizontally scrollable tab strips and stat tables. No `html`/`body` overflow masking was added. Static viewport/navigation regression coverage exercises the mobile shell.
+
+Interactive 375/390/430 browser inspection, screenshots, overflow evaluation, and before/after vertical measurements could not be completed in this environment: Playwright's Chromium executable was absent, and `npx playwright install chromium` was blocked with HTTP 403 “Domain forbidden.” No measurements or screenshots are claimed.
+
+## Accessibility
+
+- The supported Game Book DOM contains one route-level return button with existing context-sensitive accessible text and native keyboard semantics.
+- Embedded BoxScore no longer leaves a visually hidden or accessibility-tree duplicate dismiss control.
+- Existing tab roles, selected states, native buttons, focus styles, and 44px tab targets remain.
+- Preparation Context is a labelled Summary section with an `h3`; unavailable details remain available to screen readers.
+- Team score-hero drill-down uses native buttons when supported.
+
+## Validation
+
+Targeted Vitest coverage verifies the single return control, single score hero, Summary placement, truthful preparation states, limited tab gating, tab switching, player/team interactions, navigation ownership, and mobile navigation availability. Production build succeeds with the repository's expected chunk-size warning. Full-suite, sim-type, deploy parity, and attempted E2E results are recorded in the pull request.
+
+## Explicit non-goals
+
+No simulation, depth-chart, injury, stat calculation/allocation, score authority, archive/save schema, worker, persistence, resolver, data fetch, Weekly Results/HQ/Team Hub/League redesign, stat table, or special-teams behavior changed. No new Game Book model, parser, or data authority was introduced.

--- a/docs/game-book-mobile-experience-v2-audit.md
+++ b/docs/game-book-mobile-experience-v2-audit.md
@@ -15,6 +15,7 @@ The final supported-game hierarchy is:
 3. existing Game Book section tabs;
 4. existing selected section content;
 5. compact Preparation Context subsection inside Summary.
+6. compact secondary Review Next Week action after Preparation Context.
 
 The redundant full `ScreenHeader`, standalone preparation card, outer “Game Book Detail” card, sticky duplicate score, and embedded close button were removed from the supported-game composition rather than visually hidden. Standalone/non-embedded BoxScore dismiss behavior remains intact.
 
@@ -22,6 +23,7 @@ The redundant full `ScreenHeader`, standalone preparation card, outer “Game Bo
 
 - Score, matchup, W/L/tie, week, and season continue to come from the existing `buildGameBookPresentation` result consumed by `BoxScore`; no score is recalculated.
 - The one return button calls the existing `onBack` callback. No route, navigation state, or bottom-navigation ownership changed.
+- Review Next Week calls the existing `onNavigate('Weekly Prep')` callback already supplied by `LeagueDashboard`; no destination or navigation owner was introduced.
 - Preparation Context still comes from `buildWeeklyDecisionImpact` and the existing `classifyPreparationBullet` rules. “Not recorded” retains the original explanatory text for assistive technology; generic and no-marker fallbacks remain explicit.
 - Team abbreviations in the score hero use the existing `TeamButton`, retaining drill-down when an `onTeamSelect` callback and team ID are available.
 - Player links and their Game Book return context are unchanged.
@@ -52,6 +54,7 @@ Interactive 375/390/430 browser inspection, screenshots, overflow evaluation, an
 - Embedded BoxScore no longer leaves a visually hidden or accessibility-tree duplicate dismiss control.
 - Existing tab roles, selected states, native buttons, focus styles, and 44px tab targets remain.
 - Preparation Context is a labelled Summary section with an `h3`; unavailable details remain available to screen readers.
+- The visible score heading owns the final score's accessible name. The retained `game-book-final-score` test hook is `aria-hidden` so assistive technology does not announce the same final twice.
 - Team score-hero drill-down uses native buttons when supported.
 
 ## Validation

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -220,8 +220,8 @@ function BoxScore({
             </span>
           )}
         </h1>
-        {/* Machine-readable line preserved for tests and screen readers */}
-        <div className="sr-only" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
+        {/* Stable machine-readable test hook; hidden from AT to avoid announcing the heading twice. */}
+        <div className="sr-only" aria-hidden="true" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
         <div className="bs-sheet-meta">Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
       </div>
 

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -46,6 +46,7 @@ function BoxScore({
   isManualSimRun = false,
   backLabel = "Back to flow",
   presentation = null,
+  summarySupplement = null,
 }) {
   const [activeTab, setActiveTab] = useState('passing');
   const [activeView, setActiveView] = useState('summary');
@@ -78,7 +79,7 @@ function BoxScore({
   if (!vm || vm.status === "unavailable") {
     return (
       <div className={`bs-sheet${embedded ? " bs-sheet--embedded" : ""}`} data-testid="box-score-sheet">
-        <button
+        {!embedded && <button
           type="button"
           className="bs-sheet-dismiss"
           data-testid="game-book-close"
@@ -86,7 +87,7 @@ function BoxScore({
           aria-label="Close box score"
         >
           ✕
-        </button>
+        </button>}
         <p className="bs-sheet-unavailable">Game data missing.</p>
       </div>
     );
@@ -195,7 +196,7 @@ function BoxScore({
       data-testid="box-score-sheet"
     >
       {/* Single ✕ dismiss — top-right */}
-      <button
+      {!embedded && <button
         type="button"
         className="bs-sheet-dismiss"
         data-testid="game-book-close"
@@ -203,22 +204,22 @@ function BoxScore({
         aria-label="Close box score"
       >
         ✕
-      </button>
+      </button>}
 
       {/* ── SCORE HERO ~60px — priority 1: what happened ───────────────── */}
       <div className="bs-sheet-hero" data-testid="game-book-score-hero">
-        <div className="bs-sheet-score-display">
-          <span className="bs-sheet-abbr">{awayAbbr}</span>
+        <h1 className="bs-sheet-score-display" aria-label={vm.finalScoreLine}>
+          <span className="bs-sheet-abbr"><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></span>
           <span className="bs-sheet-pts">{awayScore}</span>
           <span className="bs-sheet-sep">·</span>
           <span className="bs-sheet-pts">{homeScore}</span>
-          <span className="bs-sheet-abbr">{homeAbbr}</span>
+          <span className="bs-sheet-abbr"><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></span>
           {wlLabel && (
             <span className={`bs-sheet-wl bs-sheet-wl--${wlTone}`} aria-label={wlLabel === "W" ? "Win" : wlLabel === "L" ? "Loss" : "Tie"}>
               {wlLabel}
             </span>
           )}
-        </div>
+        </h1>
         {/* Machine-readable line preserved for tests and screen readers */}
         <div className="sr-only" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
         <div className="bs-sheet-meta">Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
@@ -359,6 +360,8 @@ function BoxScore({
           )}
         </div>
       )}
+
+      {activeView === 'summary' && summarySupplement}
 
       {/* ── FULL PLAYER STATS — priority 5, collapsed dense tables ───────── */}
       {activeView === 'players' && <section className="bs-sheet-details" data-testid="game-book-player-stats" aria-label="Player Stats">

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -56,6 +56,7 @@ describe('BoxScore compact sheet — core rendering', () => {
       <BoxScore gameId="2031_w4_1_2" league={baseLeague} actions={{ getBoxScore: vi.fn() }} scheduleGame={scheduleGame} embedded />,
     );
     expect(getByTestId('game-book-final-score').textContent).toBe('BUF 24 - 13 KC');
+    expect(getByTestId('game-book-final-score').getAttribute('aria-hidden')).toBe('true');
     expect(container.textContent).not.toContain('Game Book unavailable');
   });
 

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -241,7 +241,7 @@ describe('BoxScore compact sheet — core rendering', () => {
   it('single ✕ dismiss button falls back to onBack when onClose is absent', () => {
     const onBack = vi.fn();
     const { getByTestId } = render(
-      <BoxScore gameId="g-back" league={{ ...baseLeague, gameById: { 'g-back': { homeId: 1, awayId: 2, homeScore: 14, awayScore: 7 } } }} onBack={onBack} embedded />,
+      <BoxScore gameId="g-back" league={{ ...baseLeague, gameById: { 'g-back': { homeId: 1, awayId: 2, homeScore: 14, awayScore: 7 } } }} onBack={onBack} />,
     );
     fireEvent.click(getByTestId('game-book-close'));
     expect(onBack).toHaveBeenCalledTimes(1);

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -51,7 +51,7 @@ function GameBookReturnBar({ week, onBack, backLabel }) {
 }
 
 
-export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect, backLabel }) {
+export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect, onNavigate, backLabel }) {
   const weekFromId = typeof gameId === 'string' ? gameId.match(/_w(\d+)_/i)?.[1] : null;
 
   const scheduleGame = findScheduleGame(league, gameId);
@@ -196,23 +196,32 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
         scheduleGame={canonicalGame ?? scheduleGame}
         backLabel={backLabel}
         summarySupplement={(
-          <section className="game-book-preparation" data-testid="game-book-decision-summary" aria-labelledby="game-book-preparation-heading">
-            <h3 id="game-book-preparation-heading">Preparation Context</h3>
-            <p className="game-book-preparation__note">Pregame context captured before kickoff. This does not assign direct causality.</p>
-            <dl className="game-book-prep-context" aria-label="Preparation context">
-              {categorizedPreparation.map((item) => (
-                <div key={item.key} className="game-book-prep-context__row">
-                  <dt>{item.label}</dt>
-                  <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
-                  {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
-                </div>
+          <>
+            <section className="game-book-preparation" data-testid="game-book-decision-summary" aria-labelledby="game-book-preparation-heading">
+              <h3 id="game-book-preparation-heading">Preparation Context</h3>
+              <p className="game-book-preparation__note">Pregame context captured before kickoff. This does not assign direct causality.</p>
+              <dl className="game-book-prep-context" aria-label="Preparation context">
+                {categorizedPreparation.map((item) => (
+                  <div key={item.key} className="game-book-prep-context__row">
+                    <dt>{item.label}</dt>
+                    <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
+                    {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
+                  </div>
+                ))}
+              </dl>
+              {genericPreparation.map((bullet, idx) => (
+                <p key={`prep-context-generic-${idx}`} data-testid="game-book-prep-context-generic" className="app-hq-intel-item tone-info">{bullet}</p>
               ))}
-            </dl>
-            {genericPreparation.map((bullet, idx) => (
-              <p key={`prep-context-generic-${idx}`} data-testid="game-book-prep-context-generic" className="app-hq-intel-item tone-info">{bullet}</p>
-            ))}
-            {!preparationBullets.length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
-          </section>
+              {!preparationBullets.length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
+            </section>
+            {onNavigate ? (
+              <div className="game-book-summary-action">
+                <button type="button" className="btn btn-sm" data-testid="game-book-review-next-week" onClick={() => onNavigate('Weekly Prep')}>
+                  Review Next Week
+                </button>
+              </div>
+            ) : null}
+          </>
         )}
       />
     </div>

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from 'react';
 import BoxScorePanel from './BoxScorePanel.jsx';
-import { EmptyState, ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+import { EmptyState, ScreenHeader } from './ScreenSystem.jsx';
 import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
 import { buildGameBookPresentation, unwrapBoxScoreResponse } from '../utils/boxScoreViewModel.js';
 import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
@@ -30,63 +30,28 @@ export function classifyPreparationBullet(bullet) {
   return { ...match, text, unavailable: text.startsWith('No ') };
 }
 
-// Compact, mobile-first sticky chrome for the Game Book. Keeps the final score,
-// W/L result, week, and a return action above the fold so the user never has to
-// scroll to see the outcome or get back to HQ. Presentational only — it reads
-// from the already-built box-score view model and never recomputes any result.
-function GameBookStickyHeader({ detailVm, userTeamId, week, onBack, backLabel }) {
-  const hasFinal = Boolean(detailVm?.availableData?.finalScore);
-  const home = detailVm?.homeTeam ?? null;
-  const away = detailVm?.awayTeam ?? null;
-  const homeScore = detailVm?.finalScore?.home;
-  const awayScore = detailVm?.finalScore?.away;
-
-  let outcome = null; // { label, tone }
-  if (hasFinal && userTeamId != null && home && away) {
-    const userIsHome = Number(home.id) === Number(userTeamId);
-    const userIsAway = Number(away.id) === Number(userTeamId);
-    if (userIsHome || userIsAway) {
-      const userScore = userIsHome ? homeScore : awayScore;
-      const oppScore = userIsHome ? awayScore : homeScore;
-      if (Number(userScore) === Number(oppScore)) outcome = { label: 'T', tone: 'info' };
-      else if (Number(userScore) > Number(oppScore)) outcome = { label: 'W', tone: 'ok' };
-      else outcome = { label: 'L', tone: 'danger' };
-    }
-  }
-
+// Compact route-owned return chrome. Matchup identity stays in the canonical
+// BoxScore hero so the full Game Book exposes only one score surface.
+function GameBookReturnBar({ week, onBack, backLabel }) {
   return (
-    <div className="game-book-sticky-header" data-testid="game-book-sticky-header">
+    <div className="game-book-return-bar" data-testid="game-book-return-bar">
       <button
         type="button"
-        className="btn btn-sm game-book-sticky-header__back"
+        className="btn btn-sm game-book-return-bar__back"
         onClick={onBack}
-        data-testid="game-book-sticky-back"
+        data-testid="game-book-return"
       >
         ← {backLabel ?? 'Return to HQ'}
       </button>
-      <span className="game-book-sticky-header__week" data-testid="game-book-sticky-week">
-        {week != null ? `Wk ${week}` : 'Game Book'}
+      <span className="game-book-return-bar__context">
+        {week != null ? `Wk ${week} Game Book` : 'Game Book'}
       </span>
-      {hasFinal ? (
-        <span className="game-book-sticky-header__score" data-testid="game-book-sticky-score">
-          {outcome ? (
-            <span className={`game-book-sticky-header__badge tone-${outcome.tone}`} aria-hidden="true">{outcome.label}</span>
-          ) : null}
-          <span className="game-book-sticky-header__teams">
-            {away?.abbr ?? 'AWY'} {awayScore ?? '—'} – {homeScore ?? '—'} {home?.abbr ?? 'HME'}
-          </span>
-        </span>
-      ) : (
-        <span className="game-book-sticky-header__score game-book-sticky-header__score--pending" data-testid="game-book-sticky-score">
-          Final pending
-        </span>
-      )}
     </div>
   );
 }
 
 
-export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect, onNavigate, backLabel }) {
+export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect, backLabel }) {
   const weekFromId = typeof gameId === 'string' ? gameId.match(/_w(\d+)_/i)?.[1] : null;
 
   const scheduleGame = findScheduleGame(league, gameId);
@@ -123,10 +88,6 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     }),
     [league, canonicalGame, gameId, scheduleGame, weekFromId],
   );
-  const screenTitle = detailVm?.availableData?.finalScore ? detailVm.headlineSummary : 'Game Book';
-  const screenSubtitle = detailVm?.availableData?.finalScore
-    ? `${detailVm.finalScoreLine} · Game Book sections show only data recorded for this final.`
-    : 'Scan the final, review the recap narrative, compare team stats, then drill into player leaders and play detail.';
 
   // Recovery guard: onBack navigates exactly once even if the recovery action
   // is tapped repeatedly while the route transition is in flight.
@@ -219,61 +180,41 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
 
   return (
     <div className="app-screen-stack" data-testid="game-book">
-      <GameBookStickyHeader
-        detailVm={detailVm}
-        userTeamId={league?.userTeamId}
+      <GameBookReturnBar
         week={detailVm?.week ?? weekFromId ?? null}
         onBack={onBack}
         backLabel={backLabel}
       />
-      <ScreenHeader
-        eyebrow="Game Book"
-        title={screenTitle}
-        subtitle={screenSubtitle}
+      <BoxScorePanel
+        presentation={detailVm}
+        gameId={gameId}
+        actions={actions}
+        league={league}
         onBack={onBack}
-        backLabel={backLabel ?? "Return to HQ"}
-        primaryAction={(
-          <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Weekly Prep')}>
-            Review Next Week
-          </button>
-        )}
-        metadata={[
-          { label: 'Game ID', value: gameId },
-          { label: 'Season', value: league?.seasonId ?? '—' },
-          { label: 'Week', value: detailVm?.week ?? weekFromId ?? '—' },
-          { label: 'Final', value: detailVm?.finalScoreLine ?? '—' },
-        ]}
-      />
-      <div data-testid="game-book-decision-summary">
-        <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
-          <dl className="game-book-prep-context" aria-label="Preparation context">
-            {categorizedPreparation.map((item) => (
-              <div key={item.key} className="game-book-prep-context__row">
-                <dt>{item.label}</dt>
-                <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
-                {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
-              </div>
+        onPlayerSelect={onPlayerSelect}
+        onTeamSelect={onTeamSelect}
+        scheduleGame={canonicalGame ?? scheduleGame}
+        backLabel={backLabel}
+        summarySupplement={(
+          <section className="game-book-preparation" data-testid="game-book-decision-summary" aria-labelledby="game-book-preparation-heading">
+            <h3 id="game-book-preparation-heading">Preparation Context</h3>
+            <p className="game-book-preparation__note">Pregame context captured before kickoff. This does not assign direct causality.</p>
+            <dl className="game-book-prep-context" aria-label="Preparation context">
+              {categorizedPreparation.map((item) => (
+                <div key={item.key} className="game-book-prep-context__row">
+                  <dt>{item.label}</dt>
+                  <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
+                  {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
+                </div>
+              ))}
+            </dl>
+            {genericPreparation.map((bullet, idx) => (
+              <p key={`prep-context-generic-${idx}`} data-testid="game-book-prep-context-generic" className="app-hq-intel-item tone-info">{bullet}</p>
             ))}
-          </dl>
-          {genericPreparation.map((bullet, idx) => (
-            <p key={`prep-context-generic-${idx}`} data-testid="game-book-prep-context-generic" className="app-hq-intel-item tone-info">{bullet}</p>
-          ))}
-          {!preparationBullets.length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
-        </SectionCard>
-      </div>
-      <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">
-        <BoxScorePanel
-          presentation={detailVm}
-          gameId={gameId}
-          actions={actions}
-          league={league}
-          onBack={onBack}
-          onPlayerSelect={onPlayerSelect}
-          onTeamSelect={onTeamSelect}
-          scheduleGame={canonicalGame ?? scheduleGame}
-          backLabel={backLabel}
-        />
-      </SectionCard>
+            {!preparationBullets.length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
+          </section>
+        )}
+      />
     </div>
   );
 }

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -199,16 +199,16 @@ describe('GameDetailScreen score source of truth', () => {
       />,
     );
 
-    expect(container.textContent).toContain('PIT defeated CLE by 17');
+    expect(container.querySelectorAll('[data-testid="game-book-score-hero"]')).toHaveLength(1);
     expect(container.textContent).toContain('CLE 10 - 27 PIT');
     expect(getByTestId('game-book-final-score').textContent).toBe('CLE 10 - 27 PIT');
     expect(container.textContent).not.toContain('CLE 0 - 0 PIT');
     expect(container.textContent).not.toContain('finished tied');
   });
 
-  it('renders a compact sticky Game Book header with week, teams, score and W/L result', () => {
+  it('renders one return control and leaves score identity to the BoxScore hero', () => {
     const onBack = vi.fn();
-    const { getByTestId } = render(
+    const { getByTestId, queryAllByTestId } = render(
       <GameDetailScreen
         gameId="2031_w3_1_2"
         league={league}
@@ -217,17 +217,12 @@ describe('GameDetailScreen score source of truth', () => {
       />,
     );
 
-    const header = getByTestId('game-book-sticky-header');
-    expect(getByTestId('game-book-sticky-week').textContent).toContain('Wk 3');
-    const scoreText = getByTestId('game-book-sticky-score').textContent;
-    expect(scoreText).toContain('CLE');
-    expect(scoreText).toContain('PIT');
-    expect(scoreText).toContain('10');
-    expect(scoreText).toContain('27');
-    // User team (PIT, id 1) won 27-10 → W badge from the user's perspective.
-    expect(header.querySelector('.game-book-sticky-header__badge').textContent).toBe('W');
+    expect(getByTestId('game-book-return-bar').textContent).toContain('Wk 3 Game Book');
+    expect(queryAllByTestId('game-book-return')).toHaveLength(1);
+    expect(queryAllByTestId('game-book-score-hero')).toHaveLength(1);
+    expect(queryAllByTestId('game-book-close')).toHaveLength(0);
 
-    fireEvent.click(getByTestId('game-book-sticky-back'));
+    fireEvent.click(getByTestId('game-book-return'));
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -225,4 +225,29 @@ describe('GameDetailScreen score source of truth', () => {
     fireEvent.click(getByTestId('game-book-return'));
     expect(onBack).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps the compact next-week action inside Summary and uses canonical navigation ownership', () => {
+    const onNavigate = vi.fn();
+    const { getByTestId, queryAllByTestId, queryByText } = render(
+      <GameDetailScreen
+        gameId="2031_w3_1_2"
+        league={league}
+        actions={{ getBoxScore: vi.fn() }}
+        onBack={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    const summary = getByTestId('game-book-view-summary');
+    expect(summary.contains(getByTestId('game-book-decision-summary'))).toBe(true);
+    expect(summary.contains(getByTestId('game-book-review-next-week'))).toBe(true);
+    expect(queryAllByTestId('game-book-return')).toHaveLength(1);
+    expect(queryAllByTestId('game-book-score-hero')).toHaveLength(1);
+    expect(queryByText('Game Book Detail')).toBeNull();
+    expect(document.querySelector('.app-screen-header')).toBeNull();
+
+    fireEvent.click(getByTestId('game-book-review-next-week'));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Prep');
+  });
 });

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -418,7 +418,7 @@ describe('FranchiseHQ', () => {
     expect(await screen.findByTestId('game-book')).toBeTruthy();
     expect(screen.getByTestId('game-book-final-score').textContent).toContain('CHI 23 - 20 DET');
 
-    fireEvent.click(screen.getByTestId('return-to-hq'));
+    fireEvent.click(screen.getByTestId('game-book-return'));
     expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
   });
 
@@ -573,13 +573,13 @@ describe('LeagueDashboard Game Book navigation integrity', () => {
     fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
     expect(await screen.findByTestId('game-book')).toBeTruthy();
     expect(screen.getAllByTestId('game-book')).toHaveLength(1);
-    expect(screen.getAllByTestId('return-to-hq')).toHaveLength(1);
+    expect(screen.getAllByTestId('game-book-return')).toHaveLength(1);
 
     // Navigation stays available so Game Book cannot trap the weekly loop.
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
 
     // Return to HQ restores the nav.
-    fireEvent.click(screen.getByTestId('return-to-hq'));
+    fireEvent.click(screen.getByTestId('game-book-return'));
     expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
   });

--- a/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
+++ b/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
@@ -248,7 +248,7 @@ describe('Game Book navigation copy — consistent return affordances', () => {
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
   });
 
-  it('defaults the sticky header and screen header back label to "Return to HQ"', () => {
+  it('defaults the single Game Book return control to "Return to HQ"', () => {
     const { getByTestId } = render(
       <GameDetailScreen
         gameId="g-density"
@@ -257,8 +257,9 @@ describe('Game Book navigation copy — consistent return affordances', () => {
         onBack={vi.fn()}
       />,
     );
-    expect(getByTestId('game-book-sticky-back').textContent).toContain('Return to HQ');
-    expect(getByTestId('return-to-hq').textContent).toContain('Return to HQ');
+    expect(getByTestId('game-book-return').textContent).toContain('Return to HQ');
+    expect(document.querySelectorAll('[data-testid="game-book-return"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-testid="return-to-hq"]')).toHaveLength(0);
   });
 
   it('honors an explicit backLabel (e.g. returning to an intermediate results screen) consistently', () => {
@@ -271,7 +272,7 @@ describe('Game Book navigation copy — consistent return affordances', () => {
         backLabel="Back to Weekly Results"
       />,
     );
-    expect(getByTestId('game-book-sticky-back').textContent).toContain('Back to Weekly Results');
+    expect(getByTestId('game-book-return').textContent).toContain('Back to Weekly Results');
   });
 });
 

--- a/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
+++ b/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
@@ -92,17 +92,17 @@ describe('mobile Match Review flow — viewport assertions', () => {
     const seasonPulse = screen.getByTestId('season-pulse');
     fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
 
-    // Sticky Game Book header carries the final score + a return action above the fold.
-    const stickyHeader = await screen.findByTestId('game-book-sticky-header');
-    expect(stickyHeader).toBeTruthy();
-    expect(screen.getByTestId('game-book-sticky-back')).toBeTruthy();
-    expect(screen.getByTestId('game-book-sticky-score').textContent).toMatch(/\d/);
+    // Route chrome owns one return action; BoxScore owns the sole score identity.
+    expect(await screen.findByTestId('game-book-return-bar')).toBeTruthy();
+    expect(screen.getAllByTestId('game-book-return')).toHaveLength(1);
+    expect(screen.getAllByTestId('game-book-score-hero')).toHaveLength(1);
+    expect(screen.queryByTestId('game-book-close')).toBeNull();
 
     // Bottom nav remains available so Game Book cannot trap route navigation.
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
 
     // Return to HQ is reachable from the sticky header and restores the nav.
-    fireEvent.click(screen.getByTestId('game-book-sticky-back'));
+    fireEvent.click(screen.getByTestId('game-book-return'));
     expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
 

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -1606,7 +1606,7 @@
    A thin, sticky chrome row at the top of the Game Book that keeps the return
    action, week, and final score / W-L result visible above the fold on mobile.
    It is intentionally low-weight and reuses existing design tokens. */
-.game-book-sticky-header {
+.game-book-return-bar {
   position: sticky;
   top: 0;
   z-index: 20;
@@ -1619,54 +1619,5 @@
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
-
-.game-book-sticky-header__back {
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.game-book-sticky-header__week {
-  font-size: var(--text-xs);
-  font-weight: 700;
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
-.game-book-sticky-header__score {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  font-size: var(--text-sm);
-  font-weight: 800;
-  color: var(--text);
-}
-
-.game-book-sticky-header__score--pending {
-  font-weight: 600;
-  color: var(--text-muted);
-}
-
-.game-book-sticky-header__teams {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.game-book-sticky-header__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  height: 20px;
-  padding: 0 5px;
-  border-radius: var(--radius-pill, 999px);
-  font-size: 11px;
-  font-weight: 900;
-  line-height: 1;
-  color: #fff;
-}
-.game-book-sticky-header__badge.tone-ok { background: var(--success, #34C759); }
-.game-book-sticky-header__badge.tone-danger { background: var(--danger, #FF453A); }
-.game-book-sticky-header__badge.tone-info { background: var(--accent, #0A84FF); }
+.game-book-return-bar__back { flex-shrink: 0; white-space: nowrap; }
+.game-book-return-bar__context { margin-left: auto; font-size: var(--text-xs); font-weight: 700; color: var(--text-muted); }

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8045,8 +8045,8 @@ details[open] .nav-summary::after {
 .bs-sheet--embedded {
   position: static;
   max-height: none;
-  border-radius: var(--radius-lg, 12px);
-  border: 1px solid var(--hairline, #333);
+  border-radius: 0;
+  border: 0;
   box-shadow: none;
 }
 .bs-sheet-view-tabs { position: sticky; top: 0; z-index: 3; display: flex; gap: 4px; padding: 8px; overflow-x: auto; background: var(--surface); border-bottom: 1px solid var(--hairline); }
@@ -8097,7 +8097,14 @@ details[open] .nav-summary::after {
   border-bottom: 1px solid var(--hairline, #333);
 }
 
+.bs-sheet--embedded .bs-sheet-hero { padding-right: 16px; }
+
+.game-book-preparation { padding: 12px 16px; border-top: 1px solid var(--hairline); }
+.game-book-preparation h3 { margin: 0 0 3px; font-size: var(--text-sm); }
+.game-book-preparation__note { margin: 0 0 8px; color: var(--text-muted); font-size: var(--text-xs); line-height: 1.35; }
+
 .bs-sheet-score-display {
+  margin: 0;
   display: flex;
   align-items: center;
   gap: var(--space-2, 8px);

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8102,6 +8102,7 @@ details[open] .nav-summary::after {
 .game-book-preparation { padding: 12px 16px; border-top: 1px solid var(--hairline); }
 .game-book-preparation h3 { margin: 0 0 3px; font-size: var(--text-sm); }
 .game-book-preparation__note { margin: 0 0 8px; color: var(--text-muted); font-size: var(--text-xs); line-height: 1.35; }
+.game-book-summary-action { display: flex; justify-content: flex-end; padding: 0 16px 12px; }
 
 .bs-sheet-score-display {
   margin: 0;

--- a/tests/e2e/mobile_game_day_trust.spec.js
+++ b/tests/e2e/mobile_game_day_trust.spec.js
@@ -107,12 +107,13 @@ test.describe('Mobile game-day trust loop', () => {
     await boxScoreCta.click();
     await expect(page.getByTestId('game-book')).toBeVisible({ timeout: 20000 });
     await expect(page.getByTestId('game-book-recovery')).toHaveCount(0);
-    const sticky = page.getByTestId('game-book-sticky-score');
-    await expect(sticky).toContainText(String(canonical.home));
-    await expect(sticky).toContainText(String(canonical.away));
+    const scoreHero = page.getByTestId('game-book-score-hero');
+    await expect(scoreHero).toContainText(String(canonical.home));
+    await expect(scoreHero).toContainText(String(canonical.away));
+    await expect(page.getByTestId('game-book-return')).toHaveCount(1);
 
     // Return to HQ (restores postgame), then continue the weekly loop.
-    await page.getByTestId('game-book-sticky-back').click();
+    await page.getByTestId('game-book-return').click();
     await expect(page.getByTestId('box-score-trigger')).toBeVisible({ timeout: 15000 });
     await page.getByRole('button', { name: /Back to Hub/i }).click();
 
@@ -156,7 +157,7 @@ test.describe('Mobile game-day trust loop', () => {
     await expect(recovery).toBeVisible({ timeout: 20000 });
     await expect(recovery).toContainText('Game Book unavailable');
     // No fabricated final behind or inside the recovery surface.
-    await expect(page.getByTestId('game-book-sticky-score')).toHaveCount(0);
+    await expect(page.getByTestId('game-book-score-hero')).toHaveCount(0);
     await expect(recovery).not.toContainText('0 - 0');
 
     await page.getByTestId('game-book-recovery-return').click();


### PR DESCRIPTION
### Motivation

- Reduce duplicated Game Book chrome and make the Game Book read as a single cohesive record on mobile by collapsing redundant wrappers and duplicate score/return controls. 
- Preserve existing data authority: BoxScore remains the canonical score/record owner and GameDetailScreen remains the route/resolution owner. 
- Keep Preparation Context truthful and available while avoiding it blocking access to the tabs.

### Description

- Consolidated the rendered Game Book hierarchy so the route exposes one return control and `BoxScore` owns the single score/matchup identity by introducing `GameBookReturnBar` (route-owned) and removing the redundant sticky score/ScreenHeader duplication; `BoxScore` continues to render the hero score and tabs. (changed: `src/ui/components/GameDetailScreen.jsx`, `src/ui/components/BoxScore.jsx`).
- Moved the Preparation Context presentation into a compact Summary supplement (`summarySupplement`) passed into `BoxScore` so Preparation Context appears as a compact subsection inside Summary instead of a large pre-tab card, preserving all existing classification and "not recorded" semantics. (changed: `GameDetailScreen.jsx`, `BoxScore.jsx`, style tweaks in `src/ui/styles/style.css`).
- Removed the embedded dismiss button from embedded `BoxScore` instances (dismiss remains for non-embedded instances) and added team drill-down usage via existing `TeamButton` in the score hero; no score calculation, archive, persistence, worker, or simulation logic changed. (changed: `BoxScore.jsx`, tests updated accordingly).
- Styling and mobile chrome updates restricted to Game Book primitives only (no global overrides); added small layout adjustments in `src/ui/styles/app-mobile.css` and `src/ui/styles/style.css` and updated tests to use the new selectors.
- Added audit document `docs/game-book-mobile-experience-v2-audit.md` documenting baseline SHA, reproduced hierarchy, consolidation performed, authority decisions, files changed, accessibility, mobile validation notes, and non-goals.

### Testing

- Ran targeted unit suites and full unit run: `npx vitest run` / `npm run test:unit` — full unit suite passed (475 files / 5,944 tests reported passing in this environment). 
- Ran focused component tests: `src/ui/components/GameDetailScreen.test.jsx`, `src/ui/components/BoxScore.test.jsx`, `src/ui/components/__tests__/gameBookMobileDensity.test.jsx`, `src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx`, `src/ui/components/__tests__/FranchiseHQ.test.jsx` — adjustments to tests completed and all updated tests passed locally under Vitest. 
- Production build: `npm run build` succeeded (build emits repository-expected chunk-size warnings only). 
- Netlify parity checks: `npm run check:netlify-parity` and `npm run check:netlify-rules` completed successfully in this environment. 
- Playwright E2E: blocked — the environment could not download Playwright Chromium (`npx playwright install chromium` failed with HTTP 403 Domain forbidden), so interactive viewport/responsive E2E at 375/390/430 and full Playwright smoke runs could not be executed here; this is documented in the audit file. 

Files changed (summary): `src/ui/components/GameDetailScreen.jsx`, `src/ui/components/BoxScore.jsx`, updated component tests, mobile viewport tests, `src/ui/styles/app-mobile.css`, `src/ui/styles/style.css`, `tests/e2e/mobile_game_day_trust.spec.js`, and `docs/game-book-mobile-experience-v2-audit.md`.

Notes: I verified main at commit `5b59927d6f527ac37d6c85d9e3bfb8858206d065` before changes, committed the branch `feature/pr-1769-game-book-mobile-experience-v2` locally, and attempted to push, but pushing the branch and creating the remote PR was blocked by missing GitHub credentials / network restrictions in this environment; the branch and commits exist locally in this run and the audit documents the verification and test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8474e0a044832d9702ca92fa66cd32)