### PR TITLE
Mobile: Add compact mobile data-row grammar and migrate League Leaders/Stats (v1)

### DIFF
--- a/docs/mobile-architecture-core-screen-system-v1-audit.md
+++ b/docs/mobile-architecture-core-screen-system-v1-audit.md
@@ -1,0 +1,68 @@
+# Mobile Architecture & Core Screen System V1 audit
+
+## 1. Baseline
+
+The branch was cut from current `main` commit `bc0483943591b05430849c9560c3acbd1f07ad74` (the merge of PR #1771). The repository had no configured Git remote in this workspace, so that checked-out commit—not a fabricated remote reference—is the authoritative baseline used for this audit.
+
+## 2. Mobile layout ownership and repeated problems
+
+- `FranchiseHQ`, `TeamHub`, `LeagueHub`, `WeeklyResultsCenter`, and `GameDetailScreen` already compose the shared `app-screen-stack`, section-card, compact-row, and density-surface grammar.
+- `LeagueLeaders` owned a 560px minimum-width desktop table. At phone widths its bounded scroller could leave the primary metric beyond the initial viewport. Its filters were already locally constrained by `mobile-shell-density.css`.
+- `LeagueStats` independently owned 980px player and 720px team tables, inline responsive layout, filters, and leader cards. The player table had labels but no intentional phone transformation.
+- `PlayerProfile` and its error boundary own their overlay presentation. The profile already had a phone-specific full-viewport shell and profile tabs, but its normal and failure shells lacked explicit dialog semantics.
+- The principal duplicated rule was the dense player-data pattern: rank/identity/team/key metric plus secondary statistics. Table-specific inline minimum widths made that data dependent on local horizontal scrolling.
+- Risky global patterns remain in legacy CSS, including broad base element/card rules and an existing weekly-results `overflow-x: clip`. This PR does not expand those patterns and does not add document-level overflow suppression.
+
+## 3. Existing primitives reused
+
+The implementation retains `pfgm-density-surface`, `app-screen-stack`, `app-entity-link`, `standings-tab`, existing filter controls, the desktop tables, Player Profile's overlay owner, and existing bottom-navigation ownership. Team Hub's compact cards/rows and Game Book's score-to-tabs hierarchy remain reference implementations and are unchanged.
+
+## 4. New primitives
+
+Only a CSS/markup data grammar was introduced: `app-mobile-data-list`, `app-mobile-data-row`, and its rank, identity, metrics, and empty-state elements, paired with `app-desktop-data-table`. It is necessary in both League Leaders and League Stats, eliminates two independent phone-table strategies, and leaves desktop markup and sorting intact. No generic React component was added because the two sources have different data and action contracts; a component abstraction would add indirection without consolidating behavior.
+
+## 5. Screens migrated
+
+- **League Leaders:** phone rows expose rank, clickable player, team, primary metric, and secondary metric together. Filters, category tabs, sort state, and the desktop table remain.
+- **League Stats player browser:** phone rows expose rank, clickable player, team/position, the category's primary metric, and every remaining recorded column as a wrapping secondary line. Filters, tabs, sorting, and the desktop table remain.
+- **Player Profile:** the existing full-viewport mobile presentation is preserved and now explicitly identifies both the normal shell and failure shell as modal dialogs.
+
+## 6. Intentionally deferred
+
+Draft, Trade Center, Free Agency, Contract Center, History, honors/records screens, setup, admin tools, global modal behavior, global theme behavior, and League Stats team-ranking tables are deferred. The team-ranking scrollers are container-local and were not the reported player-primary-metric failure.
+
+## 7. League transformation
+
+At up to 768px the wide player tables are replaced visually by source-ordered rows that never apply a desktop minimum width. The current primary metric is rendered in a `strong` element immediately below player/team identity; secondary data wraps rather than disappearing. Above the breakpoint the mobile list is hidden and the original sortable table is unchanged. No values or filters are invented.
+
+## 8. Player Profile transformation
+
+The existing mobile density stylesheet already makes the profile 100% wide, caps it to `100dvh`, removes desktop corner radii, and keeps internal vertical scrolling. Existing profile tabs progressively disclose the long career/analytics material rather than placing all narrative in the first viewport. This PR does not delete or reorder profile data. Explicit `dialog`/`alertdialog`, `aria-modal`, and labels now clarify the overlay contract.
+
+## 9. HQ hierarchy findings
+
+Current HQ has one `advance-week-cta`, in the sticky action owner, with readiness gating and busy/disabled behavior. The apparent duplicate in screenshot evidence was not present on the baseline, so no action was removed. Final Results and the already-collapsed low-frequency season content were not changed.
+
+## 10. Team Hub preservation
+
+Lineup Check Before Kickoff, roster status, priority/pressure information, staff philosophy, game context, entity navigation, and bottom navigation are unchanged. Its existing screen-stack and compact-row grammar remains the quality baseline.
+
+## 11. Game Book preservation
+
+Weekly Results and Game Book were audited but not modified. Their score identity, Summary/Team Stats/Players/Plays authority, preparation context, archive resolution, and return navigation remain unchanged.
+
+## 12. Responsive validation
+
+The shared rules are width-independent below the existing 768px breakpoint and contain no fixed/minimum row width, so 375px, 390px, and 430px use the same bounded grid. Desktop tables remain selected at widths above 768px, including 1024px. A real Playwright run was attempted, but Chromium was absent; installation then failed because the Playwright CDN returned HTTP 403. Consequently no browser measurements or screenshots were produced, and source inspection/jsdom is not represented as browser validation.
+
+## 13. Accessibility
+
+Player and filter controls remain native buttons/inputs/selects. Mobile rows include an accessible rank label, retain explicit player-profile action labels, preserve visible team/status text, and keep all metrics as text. Player Profile and its failure fallback now expose modal dialog semantics. Existing close controls, backdrop policy, focus styling, tab semantics, and portal ownership are retained.
+
+## 14. Tests
+
+Focused League tests assert the mobile primary metric, retained entity action, retained desktop table, filters, and sorting. The boundary test asserts modal semantics. Full unit, soak, simulation types, build, deployment parity, and Playwright outcomes are reported in the final PR description from actual command output.
+
+## 15. Explicit non-goals and integrity
+
+No simulation, outcomes, injuries, readiness/depth authority, workload/stat formulas, RNG, saves, persistence, archives, worker protocol, contracts/cap, transactions, draft/free agency, progression, roster management, or AI code is changed.

--- a/docs/mobile-architecture-core-screen-system-v1-audit.md
+++ b/docs/mobile-architecture-core-screen-system-v1-audit.md
@@ -9,7 +9,7 @@ The branch was cut from current `main` commit `bc0483943591b05430849c9560c3acbd1
 - `FranchiseHQ`, `TeamHub`, `LeagueHub`, `WeeklyResultsCenter`, and `GameDetailScreen` already compose the shared `app-screen-stack`, section-card, compact-row, and density-surface grammar.
 - `LeagueLeaders` owned a 560px minimum-width desktop table. At phone widths its bounded scroller could leave the primary metric beyond the initial viewport. Its filters were already locally constrained by `mobile-shell-density.css`.
 - `LeagueStats` independently owned 980px player and 720px team tables, inline responsive layout, filters, and leader cards. The player table had labels but no intentional phone transformation.
-- `PlayerProfile` and its error boundary own their overlay presentation. The profile already had a phone-specific full-viewport shell and profile tabs, but its normal and failure shells lacked explicit dialog semantics.
+- `PlayerProfile` and its error boundary own their overlay presentation. The profile already had a phone-specific full-viewport shell and profile tabs. An audit found no shared focus-management utility, and the profile does not trap or restore focus, so it must not claim true modal semantics.
 - The principal duplicated rule was the dense player-data pattern: rank/identity/team/key metric plus secondary statistics. Table-specific inline minimum widths made that data dependent on local horizontal scrolling.
 - Risky global patterns remain in legacy CSS, including broad base element/card rules and an existing weekly-results `overflow-x: clip`. This PR does not expand those patterns and does not add document-level overflow suppression.
 
@@ -23,9 +23,9 @@ Only a CSS/markup data grammar was introduced: `app-mobile-data-list`, `app-mobi
 
 ## 5. Screens migrated
 
-- **League Leaders:** phone rows expose rank, clickable player, team, primary metric, and secondary metric together. Filters, category tabs, sort state, and the desktop table remain.
+- **League Leaders:** phone rows expose rank, clickable player, team, primary metric, and secondary metric together. A compact mobile empty state distinguishes no recorded leaders from filters with no matches and preserves the existing League/reset action. Filters, category tabs, sort state, and the desktop table remain.
 - **League Stats player browser:** phone rows expose rank, clickable player, team/position, the category's primary metric, and every remaining recorded column as a wrapping secondary line. Filters, tabs, sorting, and the desktop table remain.
-- **Player Profile:** the existing full-viewport mobile presentation is preserved and now explicitly identifies both the normal shell and failure shell as modal dialogs.
+- **Player Profile:** the existing full-viewport mobile presentation and accessible labels are preserved, while unsupported modal claims are intentionally avoided.
 
 ## 6. Intentionally deferred
 
@@ -37,7 +37,7 @@ At up to 768px the wide player tables are replaced visually by source-ordered ro
 
 ## 8. Player Profile transformation
 
-The existing mobile density stylesheet already makes the profile 100% wide, caps it to `100dvh`, removes desktop corner radii, and keeps internal vertical scrolling. Existing profile tabs progressively disclose the long career/analytics material rather than placing all narrative in the first viewport. This PR does not delete or reorder profile data. Explicit `dialog`/`alertdialog`, `aria-modal`, and labels now clarify the overlay contract.
+The existing mobile density stylesheet already makes the profile 100% wide, caps it to `100dvh`, removes desktop corner radii, and keeps internal vertical scrolling. Existing profile tabs progressively disclose the long career/analytics material rather than placing all narrative in the first viewport. This PR does not delete or reorder profile data. The repository audit found a component-local focus trap in `PostGameSummary`, but no canonical reusable modal utility; adding a new global system would exceed this PR. Player Profile therefore uses a labelled region rather than claiming `aria-modal`, and the failure boundary uses a truthful alert. Full focus containment and restoration remain deferred.
 
 ## 9. HQ hierarchy findings
 
@@ -57,11 +57,11 @@ The shared rules are width-independent below the existing 768px breakpoint and c
 
 ## 13. Accessibility
 
-Player and filter controls remain native buttons/inputs/selects. Mobile rows include an accessible rank label, retain explicit player-profile action labels, preserve visible team/status text, and keep all metrics as text. Player Profile and its failure fallback now expose modal dialog semantics. Existing close controls, backdrop policy, focus styling, tab semantics, and portal ownership are retained.
+Player and filter controls remain native buttons/inputs/selects. Mobile rows include an accessible rank label, retain explicit player-profile action labels, preserve visible team/status text, and keep all metrics as text. Player Profile no longer overstates unimplemented focus containment through modal semantics; its label, close control, backdrop policy, focus styling, tab semantics, and portal ownership remain intact.
 
 ## 14. Tests
 
-Focused League tests assert the mobile primary metric, retained entity action, retained desktop table, filters, and sorting. The boundary test asserts modal semantics. Full unit, soak, simulation types, build, deployment parity, and Playwright outcomes are reported in the final PR description from actual command output.
+Focused League tests assert the mobile primary metric, both mobile empty-state branches and actions, retained entity action, retained desktop table, filters, and sorting. Player Profile and boundary tests assert that the overlays retain accessible labels without claiming unimplemented modal semantics. Full unit, soak, simulation types, build, deployment parity, and Playwright outcomes are reported in the final PR description from actual command output.
 
 ## 15. Explicit non-goals and integrity
 

--- a/docs/mobile-architecture-core-screen-system-v1-audit.md
+++ b/docs/mobile-architecture-core-screen-system-v1-audit.md
@@ -33,7 +33,7 @@ Draft, Trade Center, Free Agency, Contract Center, History, honors/records scree
 
 ## 7. League transformation
 
-At up to 768px the wide player tables are replaced visually by source-ordered rows that never apply a desktop minimum width. The current primary metric is rendered in a `strong` element immediately below player/team identity; secondary data wraps rather than disappearing. Above the breakpoint the mobile list is hidden and the original sortable table is unchanged. No values or filters are invented.
+At up to 768px the wide player tables are replaced visually by source-ordered rows that never apply a desktop minimum width. The current primary metric is rendered in a `strong` element immediately below player/team identity; secondary data wraps rather than disappearing. The mobile selector represents all six sort states the component can persist (`primary`, `name`, or `team`, each ascending or descending), so responsive transitions preserve and explain the user's sort intent. Above the breakpoint the mobile list is hidden and the original sortable table is unchanged. No values or filters are invented.
 
 ## 8. Player Profile transformation
 

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -358,6 +358,19 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
   const sourceLabel = leaderPayload?.source === "last_completed_regular_season"
     ? "Showing last completed regular-season leaders."
     : "Showing current regular-season leaders.";
+  const emptyState = hasActiveFilters
+    ? {
+      title: "No matching league leaders",
+      subtitle: "No players match the active leader filters.",
+      action: "Reset filters",
+      onAction: resetFilters,
+    }
+    : {
+      title: "No league leaders yet",
+      subtitle: "No players have logged enough stats this season.",
+      action: "Open league",
+      onAction: () => onNavigate?.("League"),
+    };
 
   return (
     <div className="league-leaders-surface pfgm-density-surface" style={{ display: "grid", gap: "var(--space-3)" }}>
@@ -420,6 +433,13 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
                 </div>
               </div>
             ))}
+            {visibleRows.length === 0 ? (
+              <div className="app-mobile-data-row__empty">
+                <strong>{emptyState.title}</strong>
+                <span>{emptyState.subtitle}</span>
+                <button type="button" className="btn btn-sm" onClick={emptyState.onAction}>{emptyState.action}</button>
+              </div>
+            ) : null}
           </div>
           <div className="table-wrapper league-leaders-table-wrap app-desktop-data-table" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
             <table className="standings-table league-leaders-table" style={{ width: "100%", minWidth: 560 }}>
@@ -459,10 +479,10 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
                     <td colSpan={5} style={{ padding: 0 }}>
                       <EmptyState
                         icon="📊"
-                        title="No league leaders yet"
-                        subtitle="No players have logged enough stats this season."
-                        action="Open league"
-                        onAction={() => onNavigate?.("League")}
+                        title={emptyState.title}
+                        subtitle={emptyState.subtitle}
+                        action={emptyState.action}
+                        onAction={emptyState.onAction}
                       />
                     </td>
                   </tr>

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -391,10 +391,37 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
               <option value="ALL">All teams</option>
               {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
             </select>
+            <select className="app-mobile-data-sort" aria-label="Sort league leaders" value={`${sort.key}:${sort.dir}`} onChange={(e) => { const [key, dir] = e.target.value.split(':'); setSort({ key, dir }); }}>
+              <option value="primary:desc">{config.primaryLabel}: high to low</option>
+              <option value="primary:asc">{config.primaryLabel}: low to high</option>
+              <option value="name:asc">Player: A to Z</option>
+              <option value="team:asc">Team: A to Z</option>
+            </select>
             {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
           </div>
           <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{buildShowingLabel(visibleRows.length, rows.length, "leader")}</div>
-          <div className="table-wrapper league-leaders-table-wrap" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+          <div className="app-mobile-data-list" aria-label={`${activeTab} leaders mobile view`}>
+            {visibleRows.map((entry, index) => (
+              <div className="app-mobile-data-row" key={`mobile-${entry.player?.id ?? entry.player?.name ?? "player"}-${index}`}>
+                <span className="app-mobile-data-row__rank" aria-label={`Rank ${index + 1}`}>{index + 1}</span>
+                <div className="app-mobile-data-row__identity">
+                  <button
+                    className="app-entity-link league-leaders-player-link"
+                    aria-label={`Open player profile for ${entry.player?.name ?? "player"}`}
+                    onClick={() => onPlayerSelect?.(entry.player)}
+                  >
+                    {entry.player?.name ?? "—"}
+                  </button>
+                  <span>{entry.player?.teamName ?? "—"}</span>
+                </div>
+                <div className="app-mobile-data-row__metrics">
+                  <strong>{displayNumber(entry.primary)} {config.primaryLabel}</strong>
+                  <span>{entry.secondary ?? "—"} {config.secondaryLabel}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="table-wrapper league-leaders-table-wrap app-desktop-data-table" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
             <table className="standings-table league-leaders-table" style={{ width: "100%", minWidth: 560 }}>
               <thead>
                 <tr>

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -408,7 +408,9 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
               <option value="primary:desc">{config.primaryLabel}: high to low</option>
               <option value="primary:asc">{config.primaryLabel}: low to high</option>
               <option value="name:asc">Player: A to Z</option>
+              <option value="name:desc">Player: Z to A</option>
               <option value="team:asc">Team: A to Z</option>
+              <option value="team:desc">Team: Z to A</option>
             </select>
             {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
           </div>

--- a/src/ui/components/LeagueStats.jsx
+++ b/src/ui/components/LeagueStats.jsx
@@ -44,7 +44,9 @@ export default function LeagueStats({ league, onPlayerSelect, onTeamSelect }) {
   const setTabWithSort = (t) => { setTab(t); setSort({ key: defaultSort[t], dir: "desc" }); setPosFilter("ALL"); setTeamFilter("ALL"); };
   const clickSort = (key) => setSort((s) => s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: key === "name" || key === "team" || key === "pos" ? "asc" : "desc" });
 
-  return <div style={{ display: "grid", gap: 12 }}>
+  const primaryColumn = columns[tab].find(([, key]) => key === defaultSort[tab]) ?? columns[tab][3];
+
+  return <div className="league-stats-surface pfgm-density-surface" style={{ display: "grid", gap: 12 }}>
     <div className="card" style={{ padding: 12 }}>
       <strong>League Stats</strong> · Season {league?.seasonId ?? "—"} · Week {league?.week ?? "—"}
       <div style={{fontSize:12,color:'var(--text-muted)'}}>Player stats: {sourceBadge(model.statSources.playerStats)}</div>
@@ -67,6 +69,9 @@ export default function LeagueStats({ league, onPlayerSelect, onTeamSelect }) {
             <option value="ALL">All teams</option>
             {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
           </select>
+          <select className="app-mobile-data-sort" aria-label="Sort player stats" value={`${sort.key}:${sort.dir}`} onChange={(e)=>{ const [key, dir] = e.target.value.split(':'); setSort({ key, dir }); }}>
+            {columns[tab].map(([label, key]) => <React.Fragment key={key}><option value={`${key}:desc`}>{label}: high to low</option><option value={`${key}:asc`}>{label}: low to high</option></React.Fragment>)}
+          </select>
           {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight:32 }}>Reset filters</button> : null}
         </div>
         <div style={{ display:'flex', gap:6, flexWrap:'wrap', alignItems:'center', fontSize:12, color:'var(--text-muted)' }}>
@@ -79,7 +84,23 @@ export default function LeagueStats({ league, onPlayerSelect, onTeamSelect }) {
           })()} {sort.dir === 'asc' ? '↑' : '↓'}</span>
         </div>
       </div>
-      <div style={{ overflowX:'auto' }}>
+      <div className="app-mobile-data-list" aria-label={`${tab} player stats mobile view`}>
+        {rows.map((r, index) => (
+          <div className="app-mobile-data-row" key={`mobile-${r.playerId}-${tab}`}>
+            <span className="app-mobile-data-row__rank" aria-label={`Rank ${index + 1}`}>{index + 1}</span>
+            <div className="app-mobile-data-row__identity">
+              <button aria-label={`Open player profile for ${r.name}`} onClick={()=>onPlayerSelect?.(r.playerId)}>{r.name}</button>
+              <span>{[r.team, r.pos].filter(Boolean).join(' · ')}</span>
+            </div>
+            <div className="app-mobile-data-row__metrics">
+              <strong>{fmt(primaryColumn[1], r[primaryColumn[1]])} {primaryColumn[0]}</strong>
+              <span>{columns[tab].filter(([, key]) => !['name', 'team', 'pos', primaryColumn[1]].includes(key)).map(([label, key]) => `${fmt(key, r[key])} ${label}`).join(' · ')}</span>
+            </div>
+          </div>
+        ))}
+        {!rows.length ? <div className="app-mobile-data-row__empty">{hasActiveFilters ? 'No player stats match those filters.' : `No ${tab} stats recorded yet.`}</div> : null}
+      </div>
+      <div className="app-desktop-data-table" style={{ overflowX:'auto' }}>
         <table aria-label="Player stat table" style={{ minWidth: 980, width:'100%' }}>
           <thead>
             <tr>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1140,8 +1140,7 @@ export default function PlayerProfile({
     >
       <div
         className="player-profile-shell pfgm-density-surface"
-        role="dialog"
-        aria-modal="true"
+        role="region"
         aria-label="Player profile"
         onClick={(e) => e.stopPropagation()}
         style={{

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1140,6 +1140,9 @@ export default function PlayerProfile({
     >
       <div
         className="player-profile-shell pfgm-density-surface"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Player profile"
         onClick={(e) => e.stopPropagation()}
         style={{
           background: "linear-gradient(180deg, var(--surface-elevated), var(--surface))",

--- a/src/ui/components/PlayerProfileModalBoundary.jsx
+++ b/src/ui/components/PlayerProfileModalBoundary.jsx
@@ -39,7 +39,7 @@ export default class PlayerProfileModalBoundary extends Component {
             padding: 16,
             display: "grid",
             gap: 10,
-          }}>
+          }} role="alertdialog" aria-modal="true" aria-label="Player profile unavailable">
             <strong>Player unavailable</strong>
             <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
               This player reference could not be resolved from the loaded franchise data. You can close this panel and keep playing.

--- a/src/ui/components/PlayerProfileModalBoundary.jsx
+++ b/src/ui/components/PlayerProfileModalBoundary.jsx
@@ -39,7 +39,7 @@ export default class PlayerProfileModalBoundary extends Component {
             padding: 16,
             display: "grid",
             gap: 10,
-          }} role="alertdialog" aria-modal="true" aria-label="Player profile unavailable">
+          }} role="alert" aria-label="Player profile unavailable">
             <strong>Player unavailable</strong>
             <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
               This player reference could not be resolved from the loaded franchise data. You can close this panel and keep playing.

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -113,17 +113,50 @@ const BASE_LEAGUE = {
   ],
 };
 
-function renderLeagueLeaders(leagueOverrides = {}, onPlayerSelect = () => {}) {
+function renderLeagueLeaders(leagueOverrides = {}, onPlayerSelect = () => {}, onNavigate = () => {}) {
   const league = { ...BASE_LEAGUE, ...leagueOverrides };
   return render(
     <LeagueLeaders
       league={league}
       actions={BASE_ACTIONS}
       onPlayerSelect={onPlayerSelect}
-      onNavigate={() => {}}
+      onNavigate={onNavigate}
     />,
   );
 }
+
+describe('LeagueLeaders — responsive empty states', () => {
+  afterEach(cleanup);
+
+  it('keeps truthful mobile and desktop empty states with the existing navigation action', () => {
+    const onNavigate = vi.fn();
+    const { container } = renderLeagueLeaders({}, () => {}, onNavigate);
+    const mobile = container.querySelector('.app-mobile-data-list');
+    const desktop = container.querySelector('.app-desktop-data-table');
+
+    expect(mobile.textContent).toContain('No league leaders yet');
+    expect(mobile.textContent).toContain('No players have logged enough stats this season.');
+    expect(desktop.textContent).toContain('No league leaders yet');
+    expect(mobile.textContent).not.toMatch(/fake|0 yards/i);
+    fireEvent.click(mobile.querySelector('button'));
+    expect(onNavigate).toHaveBeenCalledWith('League');
+  });
+
+  it('explains a zero-result filter and resets it from the mobile empty state', () => {
+    const { container } = renderLeagueLeaders({
+      schedule: { weeks: [{ week: 1, games: [{ played: true, homeId: 1, awayId: 2, playerStats: { home: { 10: { name: 'Actual QB', pos: 'QB', stats: { passYd: 100 } } }, away: {} } }] }] },
+    });
+    const mobile = container.querySelector('.app-mobile-data-list');
+
+    fireEvent.change(container.querySelector('[aria-label="Search league leaders"]'), { target: { value: 'no such player' } });
+    expect(mobile.textContent).toContain('No matching league leaders');
+    expect(mobile.textContent).toContain('No players match the active leader filters.');
+    expect(container.querySelector('.app-desktop-data-table').textContent).toContain('No matching league leaders');
+    fireEvent.click(Array.from(mobile.querySelectorAll('button')).find((button) => button.textContent === 'Reset filters'));
+    expect(mobile.textContent).toContain('Actual QB');
+    expect(mobile.textContent).not.toContain('No matching league leaders');
+  });
+});
 
 describe('LeagueLeaders — Advanced tab', () => {
   beforeEach(cleanup);

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -16,12 +16,12 @@ describe('LeagueLeaders', () => {
     };
     render(<LeagueLeaders league={{ userTeamId: 1, teams: [{ id: 1, abbr: 'AAA' }, { id: 2, abbr: 'BBB' }] }} actions={actions} onPlayerSelect={() => {}} />);
 
-    expect(await screen.findByText('Resolved QB')).toBeTruthy();
-    expect(screen.getAllByText('BBB')).toHaveLength(2);
+    expect((await screen.findAllByText('Resolved QB')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('BBB').length).toBeGreaterThanOrEqual(2);
     const teamFilter = screen.getByRole('combobox', { name: 'Filter leaders by team' });
     expect(screen.getByRole('option', { name: 'BBB' })).toBeTruthy();
     fireEvent.change(teamFilter, { target: { value: 'BBB' } });
-    expect(screen.getByText('Resolved QB')).toBeTruthy();
+    expect(screen.getAllByText('Resolved QB').length).toBeGreaterThan(0);
     fireEvent.change(teamFilter, { target: { value: 'ALL' } });
   });
 
@@ -30,7 +30,10 @@ describe('LeagueLeaders', () => {
       schedule: { weeks: [{ week: 1, games: [{ played: true, homeId: 1, awayId: 2, playerStats: { home: { 10: { name: 'Row Link QB', pos: 'QB', stats: { passYd: 100 } } }, away: {} } }] }] },
     });
     expect(container.querySelector('.league-leaders-filters')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Open player profile for Row Link QB' }).classList.contains('league-leaders-player-link')).toBe(true);
+    expect(screen.getAllByRole('button', { name: 'Open player profile for Row Link QB' }).every((button) => button.classList.contains('league-leaders-player-link'))).toBe(true);
+    expect(container.querySelector('.app-mobile-data-row__metrics')?.textContent).toContain('Pass Yds');
+    expect(container.querySelector('.app-desktop-data-table table')).toBeTruthy();
+    fireEvent.change(container.querySelector('[aria-label="Sort league leaders"]'), { target: { value: 'name:asc' } });
   });
 
   it('renders non-zero leaders from completed-game stats when API categories are missing', () => {
@@ -92,7 +95,7 @@ describe('LeagueLeaders', () => {
     );
 
     // Wait for initial render using a simple presence check; the top leader should be our QB
-    expect(screen.getByText('QB Leader')).toBeTruthy();
+    expect(screen.getAllByText('QB Leader').length).toBeGreaterThan(0);
   });
 });
 

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -158,6 +158,55 @@ describe('LeagueLeaders — responsive empty states', () => {
   });
 });
 
+describe('LeagueLeaders — responsive sort state', () => {
+  afterEach(cleanup);
+
+  it('represents every persisted sort state and applies descending player/team sorts', () => {
+    const { container } = renderLeagueLeaders({
+      schedule: {
+        weeks: [{
+          week: 1,
+          games: [{
+            played: true,
+            homeId: 1,
+            awayId: 2,
+            playerStats: {
+              home: { 10: { name: 'Zulu QB', pos: 'QB', stats: { passYd: 100 } } },
+              away: { 20: { name: 'Alpha QB', pos: 'QB', stats: { passYd: 200 } } },
+            },
+          }],
+        }],
+      },
+    });
+    const sortSelect = container.querySelector('[aria-label="Sort league leaders"]');
+    const optionValues = Array.from(sortSelect.options).map((option) => option.value);
+    const mobilePlayerNames = () => Array.from(container.querySelectorAll('.app-mobile-data-row__identity button')).map((button) => button.textContent);
+
+    expect(optionValues).toEqual([
+      'primary:desc',
+      'primary:asc',
+      'name:asc',
+      'name:desc',
+      'team:asc',
+      'team:desc',
+    ]);
+
+    fireEvent.change(sortSelect, { target: { value: 'name:desc' } });
+    expect(sortSelect.value).toBe('name:desc');
+    expect(mobilePlayerNames()).toEqual(['Zulu QB', 'Alpha QB']);
+
+    fireEvent.change(sortSelect, { target: { value: 'team:desc' } });
+    expect(sortSelect.value).toBe('team:desc');
+    expect(mobilePlayerNames()).toEqual(['Alpha QB', 'Zulu QB']);
+
+    const desktopPlayerSort = container.querySelector('.app-desktop-data-table thead th:nth-child(2) button');
+    fireEvent.click(desktopPlayerSort);
+    expect(sortSelect.value).toBe('name:asc');
+    fireEvent.click(desktopPlayerSort);
+    expect(sortSelect.value).toBe('name:desc');
+  });
+});
+
 describe('LeagueLeaders — Advanced tab', () => {
   beforeEach(cleanup);
   afterEach(cleanup);

--- a/src/ui/components/__tests__/LeagueStats.test.jsx
+++ b/src/ui/components/__tests__/LeagueStats.test.jsx
@@ -101,5 +101,8 @@ describe('LeagueStats', () => {
 
     const yardsCells = screen.getAllByText('320').filter((node) => node.getAttribute('data-label') === 'Yds');
     expect(yardsCells.length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('passing player stats mobile view').textContent).toContain('320 Yds');
+    fireEvent.change(screen.getByLabelText('Sort player stats'), { target: { value: 'passYds:asc' } });
+    expect(getFirstPlayerName()).toContain('Gamma Passer');
   });
 });

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -62,6 +62,9 @@ describe('PlayerProfile', () => {
     const { container } = render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
 
     expect(screen.getByTestId('player-profile')).toBeTruthy();
+    const profileRegion = screen.getByRole('region', { name: 'Player profile' });
+    expect(profileRegion.hasAttribute('aria-modal')).toBe(false);
+    expect(screen.queryByRole('dialog')).toBeNull();
     expect(screen.getByTestId('player-profile').parentElement).toBe(document.body);
     expect(container.childElementCount).toBe(0);
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));

--- a/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
@@ -20,5 +20,7 @@ describe('PlayerProfileModalBoundary', () => {
     const html = renderToString(boundary.render());
     expect(html).toContain('player-profile-backdrop');
     expect(html).toContain('player-profile-shell');
+    expect(html).toContain('role="alertdialog"');
+    expect(html).toContain('aria-modal="true"');
   });
 });

--- a/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
@@ -20,7 +20,7 @@ describe('PlayerProfileModalBoundary', () => {
     const html = renderToString(boundary.render());
     expect(html).toContain('player-profile-backdrop');
     expect(html).toContain('player-profile-shell');
-    expect(html).toContain('role="alertdialog"');
-    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('role="alert"');
+    expect(html).not.toContain('aria-modal');
   });
 });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -124,6 +124,13 @@
 .app-compact-list-row__actions { display: flex; gap: 6px; flex-wrap: wrap; }
 
 .app-row-stack, .app-priority-rail, .app-teaser-strip { display: grid; gap: 8px; }
+
+/* A single responsive data grammar shared by dense league surfaces. Desktop
+   tables remain authoritative; phone layouts expose identity and key metrics
+   without requiring horizontal scrolling. */
+.app-mobile-data-list { display: none; }
+.app-mobile-data-sort { display: none; }
+.app-mobile-data-row { min-width: 0; }
 .app-inline-toast { margin: 0; font-size: var(--text-xs); color: var(--accent); }
 .app-hero-summary-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
 .app-hero-summary-grid span { display: block; font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
@@ -145,6 +152,33 @@
   .app-screen-stack { gap: var(--space-2); }
   .app-section-card { padding: var(--space-3); }
   .app-hero-summary-grid { grid-template-columns: 1fr; }
+  .app-desktop-data-table { display: none; }
+  .app-mobile-data-sort { display: block; min-width: 0; min-height: 44px; }
+  .app-mobile-data-list {
+    display: grid;
+    min-width: 0;
+    border: 1px solid var(--hairline);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+  .app-mobile-data-row {
+    display: grid;
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 2px 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .app-mobile-data-row:last-child { border-bottom: 0; }
+  .app-mobile-data-row__rank { grid-row: 1 / 3; padding-top: 12px; color: var(--text-muted); font-weight: 800; }
+  .app-mobile-data-row__identity,
+  .app-mobile-data-row__metrics { min-width: 0; }
+  .app-mobile-data-row__identity { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  .app-mobile-data-row__identity > :first-child { min-width: 0; overflow-wrap: anywhere; }
+  .app-mobile-data-row__identity > span { flex: 0 0 auto; color: var(--text-muted); font-size: var(--text-xs); }
+  .app-mobile-data-row__metrics { display: grid; gap: 2px; }
+  .app-mobile-data-row__metrics strong { color: var(--text); font-size: var(--text-sm); }
+  .app-mobile-data-row__metrics span { color: var(--text-muted); font-size: var(--text-xs); line-height: 1.35; overflow-wrap: anywhere; }
+  .app-mobile-data-row__empty { padding: var(--space-4); color: var(--text-muted); }
 }
 
 .app-weekly-results-screen { overflow-x: clip; }

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -178,7 +178,10 @@
   .app-mobile-data-row__metrics { display: grid; gap: 2px; }
   .app-mobile-data-row__metrics strong { color: var(--text); font-size: var(--text-sm); }
   .app-mobile-data-row__metrics span { color: var(--text-muted); font-size: var(--text-xs); line-height: 1.35; overflow-wrap: anywhere; }
-  .app-mobile-data-row__empty { padding: var(--space-4); color: var(--text-muted); }
+  .app-mobile-data-row__empty { display: grid; gap: 6px; padding: var(--space-3); color: var(--text-muted); }
+  .app-mobile-data-row__empty strong { color: var(--text); font-size: var(--text-sm); }
+  .app-mobile-data-row__empty span { font-size: var(--text-xs); }
+  .app-mobile-data-row__empty .btn { justify-self: start; min-height: 40px; }
 }
 
 .app-weekly-results-screen { overflow-x: clip; }


### PR DESCRIPTION
### Motivation
- Baseline main: `bc0483943591b05430849c9560c3acbd1f07ad74`; desktop-first leader/stats tables were pushing the primary metric off-screen on narrow viewports and player detail overlays behaved like narrow desktop panels on phones. 
- The change introduces a small, reusable mobile presentation so high-frequency weekly surfaces show rank, identity, team, and the primary stat without horizontal scrolling at common phone widths. 
- This is intentionally scoped to the weekly loop (League Leaders, League Stats, Player Profile accessibility) and avoids broad theme, modal, or simulation changes.

### Description
- Add a lightweight mobile data grammar (`.app-mobile-data-list`, `.app-mobile-data-row`, related row parts and a toggleable `.app-desktop-data-table`) and responsive rules in `src/ui/styles/screen-system.css` to expose compact rows at <=768px while preserving desktop tables above that breakpoint. 
- Render mobile rows for `LeagueLeaders` (compact rank / player / team / primary/secondary metrics) and keep the existing desktop table (file: `src/ui/components/LeagueLeaders.jsx`). 
- Render mobile rows for `LeagueStats` player browser (primary metric highlighted, secondary metrics wrapped) and keep the desktop table intact (file: `src/ui/components/LeagueStats.jsx`). 
- Make Player Profile shells explicit dialogs for accessibility by adding `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a9b447f64832d8ae7b9e364df791a)