### PR TITLE
Canonical Rich-Unit Sparse Fallback Isolation V1

### DIFF
--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -285,6 +285,7 @@ describe('weekSimulationBridge', () => {
       { id: 1, name: 'Returner', pos: 'WR', ovr: 92, depthOrder: 1, depthChart: { rowKey: 'RS', order: 1 } },
       { id: 2, name: 'WR starter', pos: 'WR', ovr: 65, depthOrder: 1, depthChart: { rowKey: 'WR', order: 1 } },
       { id: 3, name: 'QB', pos: 'QB', ovr: 75, depthOrder: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      { id: 4, name: 'Defensive returner', pos: 'CB', ovr: 80, depthOrder: 1, depthChart: { rowKey: 'RS', order: 1 } },
     ] as any;
     const withReturnRow = aggregateTeamUnitsFromRoster(roster);
     const withoutReturnRow = aggregateTeamUnitsFromRoster(roster.map((player) => player.id === 1
@@ -293,6 +294,8 @@ describe('weekSimulationBridge', () => {
 
     expect(withReturnRow.offense).toEqual(withoutReturnRow.offense);
     expect(withReturnRow.defense).toEqual(withoutReturnRow.defense);
+    expect(withReturnRow.selectedUnitPlayerIds.offense).toContain(1);
+    expect(withReturnRow.selectedUnitPlayerIds.defense).toContain(4);
   });
 
   it.each(['DT', 'NT', 'DL'])('includes an %s alias assigned to canonical IDL when other defensive rows are full', (pos) => {
@@ -381,6 +384,25 @@ describe('weekSimulationBridge', () => {
     const units = aggregateTeamUnitsFromRoster([natural]);
 
     expect(units.selectedUnitPlayerIds.offense).toContain(natural.id);
+  });
+
+  it('excludes pure special-team players from sparse scrimmage-unit fallback', () => {
+    const roster = [
+      { id: 1, name: 'QB', pos: 'QB', ovr: 75 },
+      { id: 2, name: 'Kicker', pos: 'K', ovr: 99, depthChart: { rowKey: 'K', order: 1 } },
+      { id: 3, name: 'Punter', pos: 'P', ovr: 98, depthChart: { rowKey: 'P', order: 1 } },
+    ] as any;
+
+    const units = aggregateTeamUnitsFromRoster(roster);
+    const repeated = aggregateTeamUnitsFromRoster(roster);
+
+    expect(units.selectedUnitPlayerIds.offense).not.toContain(2);
+    expect(units.selectedUnitPlayerIds.defense).not.toContain(2);
+    expect(units.selectedUnitPlayerIds.offense).not.toContain(3);
+    expect(units.selectedUnitPlayerIds.defense).not.toContain(3);
+    expect(repeated.selectedUnitPlayerIds).toEqual(units.selectedUnitPlayerIds);
+    expect(repeated.offense).toEqual(units.offense);
+    expect(repeated.defense).toEqual(units.defense);
   });
 
   it('retains an incompatible scrimmage-row penalty without granting starter authority', () => {

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -2,7 +2,7 @@ import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
 import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
-import { DEPTH_CHART_ROWS, getCanonicalScrimmageAssignment, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
+import { DEPTH_CHART_ROWS, getPlayerScrimmageUnitRow, getScrimmageDepthAssignment, getScrimmageDepthRow } from '../depthChart.js';
 import { FOOTBALL_ROSTER_CONFIG } from '../sports/footballRosterConfig.js';
 import { isAvailableForGameDay } from '../holdouts/holdoutEngine.js';
 
@@ -145,14 +145,11 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = [], teamId?: num
     return (player: Player) => {
       const cached = cache.get(player);
       if (cached) return cached;
-      const canonicalAssignment = getCanonicalScrimmageAssignment(player);
-      const canonicalRow = canonicalAssignment
-        ? DEPTH_CHART_ROWS.find((row) => row.key === canonicalAssignment.rowKey)
-        : null;
+      const unitRow = getPlayerScrimmageUnitRow(player, group);
       const metadata = {
-        rowKey: getPlayerScrimmageUnitRow(player, group)?.key ?? null,
+        rowKey: unitRow?.key ?? null,
         depthOrder: getScrimmageDepthAssignment(player, group)?.order ?? 9999,
-        eligibleForGroup: !canonicalRow || canonicalRow.group === group,
+        eligibleForGroup: unitRow != null,
       };
       cache.set(player, metadata);
       return metadata;


### PR DESCRIPTION
### Motivation
- Verified `origin/main` at `5bcdcdffc0bed9ac0e763155d438de394d392fee` and reproduced the sparse-roster leakage where pure `K`/`P` players were being considered eligible for `OFFENSE`/`DEFENSE` filler due to downstream `eligibleForGroup` logic.  
- Root cause: SPECIAL rows (e.g. `K`, `P`, `RS`) were correctly producing `null` from `getCanonicalScrimmageAssignment`, but `aggregateTeamUnitsFromRoster` treated the absence of a canonical row (`!canonicalRow`) as generic eligibility, allowing pure special-team players to contaminate scrimmage unit filler pools on undersized rosters.  
- Goal: ensure fallback eligibility for a requested scrimmage group derives from whether the player actually resolves to a legitimate scrimmage unit row for that group, without changing natural-position fallback or secondary-position authority.

### Description
- Replaced the previous canonical/`!canonicalRow` eligibility logic in `aggregateTeamUnitsFromRoster` with a single resolution to `getPlayerScrimmageUnitRow(player, group)` and set `eligibleForGroup` to `unitRow != null`, keeping `rowKey` and `depthOrder` behavior consistent.  
- Technical changes made to `src/core/sim/weekSimulationBridge.ts`: removed reliance on `getCanonicalScrimmageAssignment` for eligibility and now reuse `getPlayerScrimmageUnitRow` to determine both `rowKey` and `eligibleForGroup`.  
- Tests added/extended in `src/core/__tests__/weekSimulationBridge.test.ts`: a focused adversarial test that proves pure `K` and pure `P` do not enter `selectedUnitPlayerIds.offense` or `selectedUnitPlayerIds.defense`, and an RS regression tweak to assert RS players keep natural-position participation without gaining scrimmage authority.  
- Changes committed locally under commit `4d7b03dd43cf04315ae4f4eb308236d85329a085` on branch `codex/canonical-rich-unit-sparse-fallback-isolation-v1`.

### Testing
- Ran the focused unit suite: `npm run test:unit -- src/core/__tests__/weekSimulationBridge.test.ts` and observed `22 passed` after the fix.  
- Ran static/type and build checks: `npm run check:sim-types` succeeded and `npm run build` succeeded (produced the repository-expected chunk-size warning only).  
- Ran the full unit suite and soak checks: `npm run test:unit` completed with `478 files / 5985 tests passed`, and `npm run test:soak` completed with `8 files / 103 tests passed`.  
- Note: `git push` of the feature branch failed in this environment due to missing GitHub credentials (`could not read Username for 'https://github.com'`), so a hosted PR URL was not created from this environment; local branch and commit are prepared for push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ca8fd5c90832dae4682890a9cfff7)