### PR TITLE
Statistical Presentation Integrity V1

### DIFF
--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -13,10 +13,10 @@ const CATEGORY_CONFIG = {
     secondaryLabel: "TD / Cmp%",
     getPrimary: (player) => stat(player, ["passingYards", "passYd"]),
     getSecondary: (player) => {
-      const td = stat(player, ["touchdowns", "passTD", "passTDs"]);
+      const td = stat(player, ["passTD", "passTDs", "touchdowns"]);
       const comp = stat(player, ["completions", "passComp"]);
       const att = stat(player, ["attempts", "passAtt"]);
-      const pct = att > 0 ? (comp / att) * 100 : 0;
+      const pct = comp == null || att == null ? undefined : att > 0 ? (comp / att) * 100 : 0;
       return `${displayNumber(td)} / ${displayNumber(pct, 1, "%")}`;
     },
   },
@@ -28,7 +28,7 @@ const CATEGORY_CONFIG = {
       const td = stat(player, ["rushingTDs", "rushTD", "rushTDs"]);
       const yds = stat(player, ["rushingYards", "rushYd", "rushYds"]);
       const att = stat(player, ["rushingAttempts", "rushAtt"]);
-      const ypc = att > 0 ? yds / att : 0;
+      const ypc = yds == null || att == null ? undefined : att > 0 ? yds / att : 0;
       return `${displayNumber(td)} / ${displayNumber(ypc, 1)}`;
     },
   },
@@ -62,7 +62,7 @@ const CATEGORY_CONFIG = {
   Interceptions: {
     primaryLabel: "INT",
     secondaryLabel: "PD / Tkl",
-    getPrimary: (player) => stat(player, ["interceptions", "ints"]),
+    getPrimary: (player) => stat(player, ["interceptions", "defInterceptions", "ints"]),
     getSecondary: (player) => `${displayNumber(stat(player, ["passesDefended"]))} / ${displayNumber(stat(player, ["tackles", "totalTackles"]))}`,
   },
   Kicking: {
@@ -73,22 +73,28 @@ const CATEGORY_CONFIG = {
       const made = stat(player, ["fgm", "fgMade", "fieldGoalsMade"]);
       const att = stat(player, ["fga", "fgAtt", "fieldGoalsAttempted"]);
       const pts = stat(player, ["kickingPoints", "points", "pts"]);
-      const pct = att > 0 ? (made / att) * 100 : 0;
+      const pct = made == null || att == null ? undefined : att > 0 ? (made / att) * 100 : 0;
       return `${displayNumber(pct, 1, "%")} / ${displayNumber(pts)}`;
     },
   },
 };
 
 function stat(player, keys) {
-  const source = player?.stats ?? player?.seasonStats ?? player?.totals ?? {};
-  const fromSource = keys.reduce((value, key) => (value != null ? value : source?.[key]), null);
-  const fromPlayer = keys.reduce((value, key) => (value != null ? value : player?.[key]), null);
-  return Number(fromSource ?? fromPlayer ?? 0) || 0;
+  const hasCanonicalStats = player?.canonicalStats && typeof player.canonicalStats === "object";
+  const sources = hasCanonicalStats
+    ? [player?.totals, player.canonicalStats]
+    : [player?.totals, player?.stats, player?.seasonStats, player];
+  for (const source of sources) {
+    for (const key of keys) {
+      if (source?.[key] != null && Number.isFinite(Number(source[key]))) return Number(source[key]);
+    }
+  }
+  return undefined;
 }
 
 function displayNumber(value, decimals = 0, suffix = "") {
-  const safe = Number(value ?? 0) || 0;
-  if (safe === 0) return "—";
+  if (value == null || !Number.isFinite(Number(value))) return "—";
+  const safe = Number(value);
   return `${safe.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix}`;
 }
 
@@ -115,12 +121,12 @@ function resolveTeamIdentity(row, teams) {
 }
 
 const API_TAB_MAP = Object.freeze({
-  Passing: { category: "passing", primaryKey: "passYards", secondaryKey: "passTDs" },
-  Rushing: { category: "rushing", primaryKey: "rushYards", secondaryKey: "rushTDs" },
-  Receiving: { category: "receiving", primaryKey: "recYards", secondaryKey: "receptions" },
-  Tackles: { category: "defense", primaryKey: "tackles", secondaryKey: "sacks" },
-  Sacks: { category: "defense", primaryKey: "sacks", secondaryKey: "pressures" },
-  Interceptions: { category: "defense", primaryKey: "interceptions", secondaryKey: "passesDefended" },
+  Passing: { category: "passing", primaryKey: "passYards" },
+  Rushing: { category: "rushing", primaryKey: "rushYards" },
+  Receiving: { category: "receiving", primaryKey: "recYards" },
+  Tackles: { category: "defense", primaryKey: "tackles" },
+  Sacks: { category: "defense", primaryKey: "sacks" },
+  Interceptions: { category: "defense", primaryKey: "interceptions" },
   // Kicking leaders currently come from local aggregation only.
 });
 
@@ -277,10 +283,8 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
       const safeCategories = getSafeLeagueLeaderCategories(remoteCategories);
       const bucket = safeCategories?.[apiConfig.category] ?? {};
       const primaryRows = normalizeLeaderRows(bucket?.[apiConfig.primaryKey]).slice(0, 10);
-      const secondaryMap = new Map(
-        normalizeLeaderRows(bucket?.[apiConfig.secondaryKey]).map((row) => [String(row.id), row.value]),
-      );
       if (primaryRows.length > 0) {
+        const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
         return primaryRows.map((row) => {
           const identity = resolveTeamIdentity(row.raw, teams);
           return ({
@@ -294,7 +298,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
               isUserTeam: Number(identity.teamId) === Number(league?.userTeamId),
             },
             primary: row.value,
-            secondary: displayNumber(secondaryMap.get(String(row.id))),
+            secondary: config.getSecondary(row.raw),
           });
         });
       }

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -321,19 +321,23 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
 
     const sourceRows = model.playerTables?.[bucketKey] ?? [];
     return sourceRows
-      .map((row) => ({
-        player: {
-          ...row,
-          id: row.playerId,
-          name: row.name,
-          teamName: row.team,
-          teamId: row.teamId,
-          pos: row.pos ?? row.position ?? "",
-          isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
-        },
-        primary: config.getPrimary(row) ?? 0,
-        secondary: config.getSecondary(row),
-      }))
+      .map((row) => {
+        const primary = config.getPrimary(row);
+        return {
+          player: {
+            ...row,
+            id: row.playerId,
+            name: row.name,
+            teamName: row.team,
+            teamId: row.teamId,
+            pos: row.pos ?? row.position ?? "",
+            isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
+          },
+          primary,
+          secondary: config.getSecondary(row),
+        };
+      })
+      .filter((entry) => Number.isFinite(entry.primary))
       .sort((a, b) => (b.primary ?? 0) - (a.primary ?? 0))
       .slice(0, 10);
   }, [activeTab, league?.userTeamId, model.playerTables, remoteCategories, teams]);

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -88,6 +88,7 @@ function stat(player, keys) {
     : [player?.totals, player?.stats, player?.seasonStats, player];
   for (const source of sources) {
     for (const key of keys) {
+      if (source === player && player?.statAvailability?.[key] === false) continue;
       if (source?.[key] != null && Number.isFinite(Number(source[key]))) return Number(source[key]);
     }
   }

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -11,11 +11,11 @@ const CATEGORY_CONFIG = {
   Passing: {
     primaryLabel: "Pass Yds",
     secondaryLabel: "TD / Cmp%",
-    getPrimary: (player) => stat(player, ["passingYards", "passYd"]),
+    getPrimary: (player) => stat(player, ["passingYards", "passYards", "passYd", "passYds"]),
     getSecondary: (player) => {
-      const td = stat(player, ["passTD", "passTDs", "touchdowns"]);
-      const comp = stat(player, ["completions", "passComp"]);
-      const att = stat(player, ["attempts", "passAtt"]);
+      const td = stat(player, ["passTD", "passTDs", "passTd", "touchdowns"]);
+      const comp = stat(player, ["completions", "passComp", "cmp"]);
+      const att = stat(player, ["attempts", "passAtt", "att"]);
       const pct = comp == null || att == null ? undefined : att > 0 ? (comp / att) * 100 : 0;
       return `${displayNumber(td)} / ${displayNumber(pct, 1, "%")}`;
     },
@@ -25,7 +25,7 @@ const CATEGORY_CONFIG = {
     secondaryLabel: "TD / YPC",
     getPrimary: (player) => stat(player, ["rushingYards", "rushYd", "rushYds"]),
     getSecondary: (player) => {
-      const td = stat(player, ["rushingTDs", "rushTD", "rushTDs"]);
+      const td = stat(player, ["rushingTDs", "rushTD", "rushTDs", "rushTd"]);
       const yds = stat(player, ["rushingYards", "rushYd", "rushYds"]);
       const att = stat(player, ["rushingAttempts", "rushAtt"]);
       const ypc = yds == null || att == null ? undefined : att > 0 ? yds / att : 0;
@@ -37,8 +37,8 @@ const CATEGORY_CONFIG = {
     secondaryLabel: "Rec / TD",
     getPrimary: (player) => stat(player, ["receivingYards", "recYd", "recYds"]),
     getSecondary: (player) => {
-      const rec = stat(player, ["receptions"]);
-      const td = stat(player, ["receivingTDs", "recTD", "recTDs"]);
+      const rec = stat(player, ["receptions", "rec"]);
+      const td = stat(player, ["receivingTDs", "recTD", "recTDs", "recTd"]);
       return `${displayNumber(rec)} / ${displayNumber(td)}`;
     },
   },
@@ -48,22 +48,24 @@ const CATEGORY_CONFIG = {
     getPrimary: (player) => {
       const solo = stat(player, ["soloTackles"]);
       const assist = stat(player, ["assistTackles"]);
-      const tackles = stat(player, ["totalTackles", "tackles"]);
-      return Math.max(tackles, solo + assist);
+      const tackles = stat(player, ["totalTackles", "tackles", "tkl"]);
+      const hasSplits = solo != null && assist != null;
+      if (tackles != null) return hasSplits ? Math.max(tackles, solo + assist) : tackles;
+      return hasSplits ? solo + assist : undefined;
     },
     getSecondary: (player) => `${displayNumber(stat(player, ["soloTackles"]))} / ${displayNumber(stat(player, ["assistTackles"]))}`,
   },
   Sacks: {
     primaryLabel: "Sacks",
     secondaryLabel: "TFL / FF",
-    getPrimary: (player) => stat(player, ["sacks"]),
-    getSecondary: (player) => `${displayNumber(stat(player, ["tacklesForLoss", "tfl"]))} / ${displayNumber(stat(player, ["forcedFumbles", "ffum"]))}`,
+    getPrimary: (player) => stat(player, ["sacks", "sack"]),
+    getSecondary: (player) => `${displayNumber(stat(player, ["tacklesForLoss", "tfl"]))} / ${displayNumber(stat(player, ["forcedFumbles", "ffum", "ff"]))}`,
   },
   Interceptions: {
     primaryLabel: "INT",
     secondaryLabel: "PD / Tkl",
-    getPrimary: (player) => stat(player, ["interceptions", "defInterceptions", "ints"]),
-    getSecondary: (player) => `${displayNumber(stat(player, ["passesDefended"]))} / ${displayNumber(stat(player, ["tackles", "totalTackles"]))}`,
+    getPrimary: (player) => stat(player, ["interceptions", "defInterceptions", "ints", "defInt"]),
+    getSecondary: (player) => `${displayNumber(stat(player, ["passesDefended", "pd"]))} / ${displayNumber(stat(player, ["tackles", "totalTackles", "tkl"]))}`,
   },
   Kicking: {
     primaryLabel: "FGM",

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -83,7 +83,7 @@ describe('LeagueLeaders', () => {
     fireEvent.change(container.querySelector('[aria-label="Sort league leaders"]'), { target: { value: 'name:asc' } });
   });
 
-  it('renders non-zero leaders from completed-game stats when API categories are missing', () => {
+  it('renders and sorts normalized completed-game fallback stats for every category', () => {
     const league = {
       userTeamId: 1,
       teams: [
@@ -118,6 +118,13 @@ describe('LeagueLeaders', () => {
                       pos: 'QB',
                       stats: { passYd: 320, passTD: 3, passComp: 24, passAtt: 33 },
                     },
+                    102: { name: 'QB Two', pos: 'QB', stats: { passYd: 100, passTD: 0, passComp: 10, passAtt: 20 } },
+                    201: { name: 'Runner', pos: 'RB', stats: { rushYd: 120, rushTD: 2, rushAtt: 20 } },
+                    301: { name: 'Receiver', pos: 'WR', stats: { recYd: 140, receptions: 7, recTD: 1 } },
+                    401: { name: 'Tackler', pos: 'LB', stats: { tackles: 101 } },
+                    402: { name: 'Rusher', pos: 'DE', stats: { sacks: 4, tacklesForLoss: 2, forcedFumbles: 1 } },
+                    403: { name: 'Ball Hawk', pos: 'CB', stats: { interceptions: 2, passesDefended: 5, tackles: 44 } },
+                    501: { name: 'Kicker', pos: 'K', stats: { fgm: 3, fga: 4, points: 10 } },
                   },
                   away: {},
                 },
@@ -132,7 +139,7 @@ describe('LeagueLeaders', () => {
       getLeagueLeaders: () => Promise.resolve({ payload: { categories: null, source: null, phase: null } }),
     };
 
-    render(
+    const { container } = render(
       <LeagueLeaders
         league={league}
         actions={actions}
@@ -141,8 +148,51 @@ describe('LeagueLeaders', () => {
       />,
     );
 
-    // Wait for initial render using a simple presence check; the top leader should be our QB
     expect(screen.getAllByText('QB Leader').length).toBeGreaterThan(0);
+    const desktopRows = () => container.querySelector('.app-desktop-data-table tbody')?.textContent ?? '';
+    const desktopNames = () => Array.from(container.querySelectorAll('.app-desktop-data-table tbody .league-leaders-player-link')).map((button) => button.textContent);
+
+    expect(desktopRows()).toContain('320');
+    expect(desktopRows()).toContain('3 / 72.7%');
+    expect(desktopNames().slice(0, 2)).toEqual(['QB Leader', 'QB Two']);
+
+    const categories = [
+      ['Rushing', '120', '2 / 6.0'],
+      ['Receiving', '140', '7 / 1'],
+      ['Tackles', '101', '— / —'],
+      ['Sacks', '4', '2 / 1'],
+      ['Interceptions', '2', '5 / 44'],
+      ['Kicking', '3', '75.0% / 10'],
+    ];
+    for (const [tab, primary, secondary] of categories) {
+      fireEvent.click(screen.getByRole('tab', { name: tab }));
+      expect(desktopRows()).toContain(primary);
+      expect(desktopRows()).toContain(secondary);
+    }
+  });
+
+  it('computes tackle primaries without treating missing splits as zero', () => {
+    const { container } = renderLeagueLeaders({
+      teams: [{
+        id: 1,
+        abbr: 'AAA',
+        roster: [
+          { id: 1, name: 'Total Only', position: 'LB', seasonStats: { tackles: 101 } },
+          { id: 2, name: 'Full Split', position: 'LB', seasonStats: { tackles: 100, soloTackles: 70, assistTackles: 40 } },
+          { id: 3, name: 'Splits Only', position: 'LB', seasonStats: { soloTackles: 60, assistTackles: 30, sacks: 1 } },
+        ],
+      }],
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tackles' }));
+    const rows = Array.from(container.querySelectorAll('.app-desktop-data-table tbody tr'));
+    const values = Object.fromEntries(rows.map((row) => {
+      const cells = row.querySelectorAll('td');
+      return [cells[1]?.textContent, { primary: cells[3]?.textContent, secondary: cells[4]?.textContent }];
+    }));
+    expect(values['Total Only']).toEqual({ primary: '101', secondary: '— / —' });
+    expect(values['Full Split']).toEqual({ primary: '110', secondary: '70 / 40' });
+    expect(values['Splits Only']).toEqual({ primary: '90', secondary: '60 / 30' });
   });
 });
 

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -127,6 +127,7 @@ describe('LeagueLeaders', () => {
                     401: { name: 'Tackler', pos: 'LB', stats: { tackles: 101 } },
                     402: { name: 'Rusher', pos: 'DE', stats: { sacks: 4, tacklesForLoss: 2, forcedFumbles: 1 } },
                     403: { name: 'Ball Hawk', pos: 'CB', stats: { interceptions: 2, passesDefended: 5, tackles: 44 } },
+                    404: { name: 'Zero INT', pos: 'S', stats: { interceptions: 0, tackles: 30 } },
                     501: { name: 'Kicker', pos: 'K', stats: { fgm: 3, fga: 4, points: 10 } },
                   },
                   away: {},
@@ -191,6 +192,12 @@ describe('LeagueLeaders', () => {
       fireEvent.click(screen.getByRole('tab', { name: tab }));
       expect(desktopRows()).toContain(primary);
       expect(desktopRows()).toContain(secondary);
+      if (tab === 'Interceptions') {
+        expect(desktopNames()).not.toContain('Tackler');
+        expect(desktopNames()).toContain('Zero INT');
+        const zeroRow = Array.from(container.querySelectorAll('.app-desktop-data-table tbody tr')).find((row) => row.textContent.includes('Zero INT'));
+        expect(zeroRow?.querySelectorAll('td')[3]?.textContent).toBe('0');
+      }
     }
   });
 

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -5,6 +5,53 @@ import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import LeagueLeaders from '../LeagueLeaders.jsx';
 
 describe('LeagueLeaders', () => {
+  afterEach(cleanup);
+  it('builds every remote row from that leader\'s canonical totals instead of independent top-N lists', async () => {
+    const actions = {
+      getLeagueLeaders: () => Promise.resolve({
+        payload: {
+          source: 'current_regular_season',
+          categories: {
+            passing: {
+              passYards: [
+                { playerId: 1, name: 'Outside TD Top Ten', pos: 'QB', teamId: 1, value: 4126, totals: { passYd: 4126, passTD: 21, passComp: 337, passAtt: 500 } },
+                { playerId: 2, name: 'Zero TD QB', pos: 'QB', teamId: 2, value: 900, totals: { passYd: 900, passTD: 0, passComp: 80, passAtt: 120 } },
+                { playerId: 3, name: 'Sparse QB', pos: 'QB', teamId: 2, value: 700, totals: { passYd: 700 } },
+              ],
+              passTDs: [{ playerId: 99, name: 'Unrelated TD Leader', value: 40, totals: { passTD: 40 } }],
+            },
+            rushing: { rushYards: [{ playerId: 4, name: 'Runner', pos: 'RB', teamId: 1, value: 1200, totals: { rushYd: 1200, rushTD: 8, rushAtt: 240 } }] },
+            receiving: { recYards: [{ playerId: 5, name: 'Receiver', pos: 'WR', teamId: 1, value: 1100, totals: { recYd: 1100, receptions: 75, recTD: 7 } }] },
+            defense: {
+              tackles: [{ playerId: 6, name: 'Tackler', pos: 'LB', teamId: 1, value: 101, totals: { tackles: 101 } }],
+              sacks: [{ playerId: 7, name: 'Rusher', pos: 'DE', teamId: 1, value: 12, totals: { sacks: 12, tacklesForLoss: 16, forcedFumbles: 3 } }],
+              interceptions: [{ playerId: 8, name: 'Ball Hawk', pos: 'CB', teamId: 2, value: 6, totals: { interceptions: 6, passesDefended: 14, tackles: 44 } }],
+            },
+          },
+        },
+      }),
+    };
+    const { container } = render(<LeagueLeaders league={BASE_LEAGUE} actions={actions} />);
+
+    await screen.findAllByText('Outside TD Top Ten');
+    expect(container.querySelector('.app-desktop-data-table tbody')?.textContent).toContain('21 / 67.4%');
+    expect(container.querySelector('.app-desktop-data-table tbody')?.textContent).toContain('0 / 66.7%');
+    expect(container.querySelector('.app-desktop-data-table tbody')?.textContent).toContain('— / —');
+    expect(container.querySelector('.app-desktop-data-table tbody')?.textContent).not.toContain('Unrelated TD Leader');
+
+    const expected = [
+      ['Rushing', '8 / 5.0'],
+      ['Receiving', '75 / 7'],
+      ['Tackles', '— / —'],
+      ['Sacks', '16 / 3'],
+      ['Interceptions', '14 / 44'],
+    ];
+    for (const [tab, secondary] of expected) {
+      fireEvent.click(screen.getByRole('tab', { name: tab }));
+      expect(container.querySelector('.app-desktop-data-table tbody')?.textContent).toContain(secondary);
+    }
+  });
+
   it('resolves API leader team identity from a real team id and exposes a working team filter', async () => {
     const actions = {
       getLeagueLeaders: () => Promise.resolve({

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -119,6 +119,9 @@ describe('LeagueLeaders', () => {
                       stats: { passYd: 320, passTD: 3, passComp: 24, passAtt: 33 },
                     },
                     102: { name: 'QB Two', pos: 'QB', stats: { passYd: 100, passTD: 0, passComp: 10, passAtt: 20 } },
+                    103: { name: 'QB Sparse', pos: 'QB', stats: { passYd: 100 } },
+                    104: { name: 'QB Explicit Zero', pos: 'QB', stats: { passYd: 100, passTD: 0, passComp: 0, passAtt: 0 } },
+                    105: { name: 'QB Partial History', pos: 'QB', stats: { passYd: 80, passTD: 1, passComp: 8, passAtt: 10 } },
                     201: { name: 'Runner', pos: 'RB', stats: { rushYd: 120, rushTD: 2, rushAtt: 20 } },
                     301: { name: 'Receiver', pos: 'WR', stats: { recYd: 140, receptions: 7, recTD: 1 } },
                     401: { name: 'Tackler', pos: 'LB', stats: { tackles: 101 } },
@@ -130,6 +133,19 @@ describe('LeagueLeaders', () => {
                 },
               },
             ],
+          }, {
+            week: 2,
+            games: [{
+              played: true,
+              homeId: 1,
+              awayId: 2,
+              homeScore: 17,
+              awayScore: 10,
+              playerStats: {
+                home: { 105: { name: 'QB Partial History', pos: 'QB', stats: { passYd: 20 } } },
+                away: {},
+              },
+            }],
           },
         ],
       },
@@ -154,7 +170,14 @@ describe('LeagueLeaders', () => {
 
     expect(desktopRows()).toContain('320');
     expect(desktopRows()).toContain('3 / 72.7%');
-    expect(desktopNames().slice(0, 2)).toEqual(['QB Leader', 'QB Two']);
+    expect(desktopNames()[0]).toBe('QB Leader');
+    const passingValues = Object.fromEntries(Array.from(container.querySelectorAll('.app-desktop-data-table tbody tr')).map((row) => {
+      const cells = row.querySelectorAll('td');
+      return [cells[1]?.textContent, { primary: cells[3]?.textContent, secondary: cells[4]?.textContent }];
+    }));
+    expect(passingValues['QB Sparse']).toEqual({ primary: '100', secondary: '— / —' });
+    expect(passingValues['QB Explicit Zero']).toEqual({ primary: '100', secondary: '0 / 0.0%' });
+    expect(passingValues['QB Partial History']).toEqual({ primary: '100', secondary: '— / —' });
 
     const categories = [
       ['Rushing', '120', '2 / 6.0'],

--- a/src/ui/utils/leagueStatsHub.js
+++ b/src/ui/utils/leagueStatsHub.js
@@ -21,6 +21,18 @@ const pickDefined = (obj = {}, keys = []) => {
 const safePct = (num, den) => (NUM(den) > 0 ? (NUM(num) / NUM(den)) * 100 : 0);
 const safeRate = (num, den) => (NUM(den) > 0 ? NUM(num) / NUM(den) : 0);
 
+const PLAYER_STAT_ALIASES = Object.freeze({
+  cmp: ["passComp", "completions"], att: ["passAtt", "attempts"], passYds: ["passYards", "passYd", "passingYards"], passTd: ["passTD", "passTd", "passTDs"], passInt: ["interceptions", "int", "passInt"],
+  rushAtt: ["rushAtt", "rushingAttempts"], rushYds: ["rushYards", "rushYd", "rushingYards"], rushTd: ["rushTD", "rushTd", "rushTDs"], rushLong: ["rushLong", "longRush"],
+  tgt: ["targets", "tgt"], rec: ["receptions", "rec"], recYds: ["recYards", "recYd", "receivingYards"], recTd: ["recTD", "recTd", "recTDs"], recLong: ["recLong", "longReception"],
+  tkl: ["tackles", "totalTackles"], sack: ["sacks"], tfl: ["tfl", "tacklesForLoss"], defInt: ["interceptions", "defInt"], pd: ["passesDefended", "passDeflections", "pd"], ff: ["forcedFumbles", "ff"], fr: ["fumbleRecoveries", "fr"], defTd: ["defTD", "defensiveTD"],
+  fgm: ["fgm", "fgMade", "fieldGoalsMade"], fga: ["fga", "fgAtt", "fieldGoalsAttempted"], xpm: ["xpm", "xpMade", "extraPointsMade"], xpa: ["xpa", "xpAtt", "extraPointsAttempted"], pts: ["kickingPoints", "points", "pts"],
+});
+
+const statAvailability = (stats = {}) => Object.fromEntries(
+  Object.entries(PLAYER_STAT_ALIASES).map(([key, aliases]) => [key, aliases.some((alias) => stats?.[alias] != null && Number.isFinite(Number(stats[alias])))]),
+);
+
 const withDerived = (row) => ({
   ...row,
   passPct: safePct(row.cmp, row.att),
@@ -47,6 +59,7 @@ function normalizeSeasonRow(player, team) {
   const s = player?.seasonStats ?? player?.stats ?? {};
   return withDerived({
     canonicalStats: s,
+    statAvailability: statAvailability(s),
     playerId: player?.id,
     name: player?.name ?? "Unknown",
     teamId: team?.id ?? null,
@@ -167,11 +180,15 @@ function aggregateGamePlayers(games, teamsById) {
       for (const [pid, raw] of Object.entries(rows)) {
         const base = normalizePlayerStats(raw?.stats ?? raw ?? {});
         const key = String(pid);
-        const prev = byPlayer.get(key) ?? normalizeSeasonRow({ id: Number(pid), name: raw?.name ?? raw?.playerName, position: raw?.pos }, team);
+        const existing = byPlayer.get(key);
+        const prev = existing ?? normalizeSeasonRow({ id: Number(pid), name: raw?.name ?? raw?.playerName, position: raw?.pos }, team);
         const next = { ...prev };
         // This row is now an aggregate, not the first game's raw stat object.
         // Its normalized numeric fields are the canonical values to present.
         delete next.canonicalStats;
+        next.statAvailability = existing
+          ? Object.fromEntries(Object.keys(PLAYER_STAT_ALIASES).map((statKey) => [statKey, Boolean(existing.statAvailability?.[statKey] && base.statAvailability?.[statKey])]))
+          : { ...base.statAvailability };
         next.g += 1;
         next.cmp += base.cmp; next.att += base.att; next.passYds += base.passYds; next.passTd += base.passTd; next.passInt += base.passInt;
         next.rushAtt += base.rushAtt; next.rushYds += base.rushYds; next.rushTd += base.rushTd; next.rushLong = Math.max(next.rushLong, base.rushLong);

--- a/src/ui/utils/leagueStatsHub.js
+++ b/src/ui/utils/leagueStatsHub.js
@@ -46,6 +46,7 @@ const withDerived = (row) => ({
 function normalizeSeasonRow(player, team) {
   const s = player?.seasonStats ?? player?.stats ?? {};
   return withDerived({
+    canonicalStats: s,
     playerId: player?.id,
     name: player?.name ?? "Unknown",
     teamId: team?.id ?? null,
@@ -168,6 +169,9 @@ function aggregateGamePlayers(games, teamsById) {
         const key = String(pid);
         const prev = byPlayer.get(key) ?? normalizeSeasonRow({ id: Number(pid), name: raw?.name ?? raw?.playerName, position: raw?.pos }, team);
         const next = { ...prev };
+        // This row is now an aggregate, not the first game's raw stat object.
+        // Its normalized numeric fields are the canonical values to present.
+        delete next.canonicalStats;
         next.g += 1;
         next.cmp += base.cmp; next.att += base.att; next.passYds += base.passYds; next.passTd += base.passTd; next.passInt += base.passInt;
         next.rushAtt += base.rushAtt; next.rushYds += base.rushYds; next.rushTd += base.rushTd; next.rushLong = Math.max(next.rushLong, base.rushLong);

--- a/src/ui/utils/leagueStatsHub.test.js
+++ b/src/ui/utils/leagueStatsHub.test.js
@@ -22,6 +22,26 @@ describe('buildLeagueStatsHubModel', () => {
     expect(model.playerTables.receiving[0].recYds).toBe(20);
   });
 
+  it('tracks explicit-zero versus missing fields conservatively across game-log aggregates', () => {
+    const game = (week, home) => ({ id: `g-${week}`, week, played: true, homeId: 1, awayId: 2, playerStats: { home, away: {} } });
+    const model = buildLeagueStatsHubModel({
+      teams: [{ id: 1, abbr: 'AAA', roster: [] }, { id: 2, abbr: 'BBB', roster: [] }],
+      schedule: [
+        game(1, {
+          1: { name: 'Sparse', stats: { passYd: 100 } },
+          2: { name: 'Explicit Zero', stats: { passYd: 100, passTD: 0, passComp: 0, passAtt: 0 } },
+          3: { name: 'Partial', stats: { passYd: 80, passTD: 1, passComp: 8, passAtt: 10 } },
+        }),
+        game(2, { 3: { name: 'Partial', stats: { passYd: 20 } } }),
+      ],
+    });
+    const rows = Object.fromEntries(model.playerTables.passing.map((row) => [row.name, row]));
+    expect(rows.Sparse.statAvailability).toMatchObject({ passYds: true, passTd: false, cmp: false, att: false });
+    expect(rows['Explicit Zero'].statAvailability).toMatchObject({ passYds: true, passTd: true, cmp: true, att: true });
+    expect(rows.Partial.passYds).toBe(100);
+    expect(rows.Partial.statAvailability).toMatchObject({ passYds: true, passTd: false, cmp: false, att: false });
+  });
+
   it('de-dupes completed games by game id across schedule shapes', () => {
     const sharedGame = { id: 's1_w1_1_2', played: true, homeId: 1, awayId: 2, homeScore: 21, awayScore: 14, teamStats:{ home:{ passYd:200,rushYd:40 }, away:{ passYd:150,rushYd:30 } } };
     const league = {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -13792,6 +13792,10 @@ async function handleGetLeagueLeaders({ mode = 'season' }, id) {
         pos:      e.pos      || '?',
         teamId:   e.teamId,
         value:    e.totals[key] || 0,
+        // Keep the ranked value for backward compatibility, while also
+        // carrying this player's canonical season line. Consumers must not
+        // reconstruct a row by joining independent top-N lists.
+        totals:   { ...(e.totals || {}) },
       }));
   };
 


### PR DESCRIPTION
### Motivation
- Fix leaderboard rows that were synthesizing secondary metrics by joining independent top‑N lists so every row reflects one player's canonical season stat line.\
- Preserve existing ranking source while making secondary metrics provably come from the same player's season totals and make zero vs missing visually distinct.\

### Description
- Worker: `GET_LEAGUE_LEADERS` top‑N rows now carry an additive `totals` object (canonical season totals) alongside existing `playerId`, `value`, and identity fields so consumers have the row's full canonical record. (changed `src/worker/worker.js`)\
- UI: League Leaders now uses the primary ranked array for ordering and reads all secondary metrics from that primary row's canonical totals via `CATEGORY_CONFIG` helpers rather than joining separate leader lists. (`src/ui/components/LeagueLeaders.jsx`)\
- Helpers: `stat()` prefers a row's canonical totals when present and returns `undefined` for missing fields; `displayNumber()` now renders numeric zeros (`0`, `0.0%`) and renders `—` for missing/unavailable values. (`src/ui/components/LeagueLeaders.jsx`)\
- Hub: `normalizeSeasonRow` exposes the original `canonicalStats` for lineage; completed‑game aggregation removes `canonicalStats` once rows are aggregated so the aggregate is authoritative. (`src/ui/utils/leagueStatsHub.js`)\
- Tests: Added an adversarial League Leaders test that covers primary top‑N/secondary outside top‑N, known zero, genuinely missing fields, same‑player sourcing, and category coverage. (`src/ui/components/__tests__/LeagueLeaders.test.jsx`)\
- Files changed: `src/worker/worker.js`, `src/ui/components/LeagueLeaders.jsx`, `src/ui/utils/leagueStatsHub.js`, `src/ui/components/__tests__/LeagueLeaders.test.jsx`.

### Testing
- Targeted unit tests: ran the League Leaders and related hub/selector tests (targeted run) — passed.\
- Unit suite: `npm run test:unit` — full suite passed (482 files / 6,002 tests ran in CI environment used here).\
- Soak: `npm run test:soak` — passed (soak subset executed).\
- Type check: `npm run check:sim-types` — passed.\
- Build and parity: `npm run build` and `npm run check:deploy` executed successfully (expected chunk‑size warning only).\
- Playwright/E2E screenshot attempt: not run here because Playwright Chromium download failed with HTTP 403 in this environment; no Playwright run was claimed.\

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dc2a3ed40832dacf5f10ad92ee762)