### PR TITLE
Deterministic Evolution Seed Contract V1

### DIFF
--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -4,6 +4,7 @@ import {
   attachFullRostersForSimulation,
   aggregateTeamUnitsFromRoster,
   buildDeterministicSeed,
+  buildEvolutionSeedKey,
   mapGameSummaryToLegacyResult,
   simulateWithOptionalNewEngine,
 } from '../sim/weekSimulationBridge.ts';
@@ -182,8 +183,33 @@ describe('weekSimulationBridge', () => {
     expect(mapped.summary.storyline).toContain('Key edge');
   });
 
-  it('builds deterministic seeds', () => {
+  it('preserves deterministic string hashing and canonical game seed semantics', () => {
     expect(buildDeterministicSeed('2026:4:1:2')).toBe(buildDeterministicSeed('2026:4:1:2'));
+    expect(buildDeterministicSeed('2026:4:1:2')).toBe(3726982352);
+  });
+
+  it('builds distinct canonical evolution keys and seeds', () => {
+    const offseason2026 = buildEvolutionSeedKey(2026, 0, 'offseason_evolution_v1');
+    const offseason2027 = buildEvolutionSeedKey(2027, 0, 'offseason_evolution_v1');
+    const weekly4 = buildEvolutionSeedKey(2026, 4, 'weekly_evolution_v1');
+    const weekly5 = buildEvolutionSeedKey(2026, 5, 'weekly_evolution_v1');
+
+    expect(offseason2026).toBe('2026:0:offseason_evolution_v1');
+    expect(weekly4).toBe('2026:4:weekly_evolution_v1');
+    expect(buildDeterministicSeed(offseason2026)).not.toBe(buildDeterministicSeed(offseason2027));
+    expect(buildDeterministicSeed(weekly4)).not.toBe(buildDeterministicSeed(weekly5));
+    expect(buildDeterministicSeed(weekly4)).not.toBe(buildDeterministicSeed(buildEvolutionSeedKey(2026, 4, 'offseason_evolution_v1')));
+  });
+
+  it.each([
+    { year: 2026, week: 4, salt: 'weekly_evolution_v1' },
+    null,
+    undefined,
+    2026,
+  ])('rejects non-string seed key %#', (input) => {
+    expect(() => buildDeterministicSeed(input as any)).toThrowError(
+      new TypeError('buildDeterministicSeed requires a string key'),
+    );
   });
 
   it('carries advancedAttribution from rich summary into bridge result', () => {

--- a/src/core/progression/__tests__/evolutionEngine.test.js
+++ b/src/core/progression/__tests__/evolutionEngine.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { processOffseasonEvolution, processWeeklyEvolution } from '../evolutionEngine.ts';
+import { buildDeterministicSeed, buildEvolutionSeedKey } from '../../sim/weekSimulationBridge.ts';
 
 function makePlayer(overrides = {}) {
   return {
@@ -32,6 +33,21 @@ describe('evolutionEngine integration behaviors', () => {
     expect(result.updates.length).toBe(2);
     expect(result.summary.processedPlayers).toBe(2);
     expect(result.summary.netDelta).not.toBe(0);
+  });
+
+  it('reproduces offseason evolution while consuming season-specific seed noise', () => {
+    const players = [makePlayer({ id: '1', age: 22 })];
+    const seed2026 = buildDeterministicSeed(buildEvolutionSeedKey(2026, 0, 'offseason_evolution_v1'));
+    const seed2027 = buildDeterministicSeed(buildEvolutionSeedKey(2027, 0, 'offseason_evolution_v1'));
+    const input2026 = { players, seasonId: 2026, seed: seed2026 };
+
+    const first = processOffseasonEvolution(input2026);
+    const repeated = processOffseasonEvolution(input2026);
+    const nextSeason = processOffseasonEvolution({ players, seasonId: 2027, seed: seed2027 });
+
+    expect(seed2026).not.toBe(seed2027);
+    expect(first).toEqual(repeated);
+    expect(first.updates[0].attributesV2).not.toEqual(nextSeason.updates[0].attributesV2);
   });
 
   it('keeps weekly evolution functional for in-season path', () => {

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -189,12 +189,19 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = [], teamId?: num
 }
 
 export function buildDeterministicSeed(input: string): number {
+  if (typeof input !== 'string') {
+    throw new TypeError('buildDeterministicSeed requires a string key');
+  }
   let hash = 2166136261;
   for (let i = 0; i < input.length; i += 1) {
     hash ^= input.charCodeAt(i);
     hash = Math.imul(hash, 16777619);
   }
   return hash >>> 0;
+}
+
+export function buildEvolutionSeedKey(year: number, week: number, salt: 'weekly_evolution_v1' | 'offseason_evolution_v1'): string {
+  return `${year}:${week}:${salt}`;
 }
 
 export function buildCanonicalEventsFromRichSummary(summary: GameSummary) {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -331,6 +331,7 @@ import {
   attachFullRostersForSimulation,
   aggregateTeamUnitsFromRoster,
   buildDeterministicSeed,
+  buildEvolutionSeedKey,
   simulateWithOptionalNewEngine,
 } from '../core/sim/weekSimulationBridge.ts';
 import { deriveFeatsFromRichGame } from '../core/sim/featDerivation.js';
@@ -5253,7 +5254,7 @@ function applyWeeklyEvolution({ week, seasonId, results, metaObj }) {
     results,
     week,
     seasonId,
-    seed: buildDeterministicSeed({ year: Number(metaObj?.year ?? 2025), week, salt: 'weekly_evolution_v1' }),
+    seed: buildDeterministicSeed(buildEvolutionSeedKey(Number(metaObj?.year ?? 2025), week, 'weekly_evolution_v1')),
     teamFocusByTeamId: buildTeamDevelopmentFocusMap(metaObj),
   });
 
@@ -11785,7 +11786,7 @@ async function handleAdvanceOffseason(payload, id) {
   const offseasonEvolution = processOffseasonEvolution({
     players: attrPlayers,
     seasonId: Number(meta?.year ?? 2025),
-    seed: buildDeterministicSeed({ year: Number(meta?.year ?? 2025), week: 0, salt: 'offseason_evolution_v1' }),
+    seed: buildDeterministicSeed(buildEvolutionSeedKey(Number(meta?.year ?? 2025), 0, 'offseason_evolution_v1')),
     teamFocusByTeamId: focusByTeamId,
   });
   const touchedAttrTeamIds = new Set();


### PR DESCRIPTION
### Motivation
- Fix a determinism bug where `buildDeterministicSeed` silently returned the raw FNV basis for non-string inputs, collapsing distinct evolution seeds into a constant.
- Ensure all evolution callers pass a canonical string key so offseason/weekly evolution noise is season-specific and reproducible.
- Prevent JavaScript worker callers from bypassing the TypeScript contract by adding a small runtime guard rather than permissive coercion.

### Description
- Added a runtime guard to `buildDeterministicSeed(input)` that throws `TypeError('buildDeterministicSeed requires a string key')` for non-string inputs and preserved the existing FNV-style hash algorithm. (src/core/sim/weekSimulationBridge.ts)
- Introduced `buildEvolutionSeedKey(year, week, salt)` to produce canonical evolution keys and migrated the two JS worker call sites to use it instead of passing objects. (src/core/sim/weekSimulationBridge.ts, src/worker/worker.js)
- Updated tests to lock a golden hash for the canonical game seed and to add adversarial coverage: same-string reproducibility, different-year/week/salt differentiation, object/null/undefined/number rejection, and an offseason fixture proving season-specific seed noise is consumed. (src/core/__tests__/weekSimulationBridge.test.ts, src/core/progression/__tests__/evolutionEngine.test.js)
- Kept rich-game seed semantics unchanged and avoided adding any weekly randomness (weekly evolution still does not materially consume `input.seed` in current code). (seed formats preserved)

### Testing
- Ran targeted unit tests: `npx vitest run src/core/__tests__/weekSimulationBridge.test.ts src/core/progression/__tests__/evolutionEngine.test.js src/core/__tests__/evolutionEngine.test.ts` — 3 files, 34 tests passed.
- Ran broader checks: `npm run check:sim-types` passed, `npm run test:unit` completed (482 files, 6010 tests passed), `npm run test:soak` completed (8 files, 103 tests passed), `npm run durability:test` completed (5 files, 83 tests passed), and `npm run build` succeeded (expected chunk-size warning); `npm run check:deploy` (Netlify parity & rules) completed.
- Golden hash locked: `buildDeterministicSeed('2026:4:1:2') === 3726982352` and adversarial tests asserting invalid JS inputs throw were added and passed.
- Playwright / first-session smoke could not be completed locally because `npx playwright install chromium` failed due to CDN HTTP 403 in this environment; the CI workflow remains unchanged and will install browsers in GitHub Actions.

(Details: audited main SHA `b038f62e3794f735367c1051098e6278dd38cc63`; commit produced `698e93fdf651f173470d55fed54a5cd4c6389368`.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e790dbc64832db8d7fcd713c37083)