### PR TITLE
Weekly Loop Presentation Integrity & Mobile Finish-State V1

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1990,7 +1990,7 @@ function AppContent() {
           injuries={skipGameSummary.injuries}
           momentumChange={skipGameSummary.momentumChange}
           onClose={() => setSkipGameSummary(null)}
-          nextWeek={nextWeekBriefingContext}
+          nextWeek={buildNextWeekStoryContext(league, { completedWeek: skipGameSummary.week }) ?? nextWeekBriefingContext}
           onPreparationAction={(destination) => {
             setGameBookBriefingStash(null);
             setSkipGameSummary(null);

--- a/src/ui/components/GameEventFeed/GameEventFeed.jsx
+++ b/src/ui/components/GameEventFeed/GameEventFeed.jsx
@@ -68,7 +68,11 @@ export default function GameEventFeed({ events = [], activeIndex = 0 }) {
                 <div className="feed-headline">{event.headline}</div>
                 {(scoreText || tags.length > 0) ? (
                   <div className="feed-meta">
-                    {scoreText ? <span className="feed-score">FINAL {scoreText}</span> : null}
+                    {scoreText ? (
+                      <span className="feed-score">
+                        {event.eventType === 'game_end' ? `FINAL ${scoreText}` : scoreText}
+                      </span>
+                    ) : null}
                     {tags.map((tag) => (
                       <span key={tag} className={`feed-tag ${TAG_CLASS[tag] || 'feed-tag-default'}`}>{tag}</span>
                     ))}

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -793,7 +793,7 @@ export default function LiveGame({
     { label: "YPC", value: statValuePair("rushYPC", 2) },
     { label: "TO", value: statValuePair("turnovers", 0) },
     { label: "Sacks", value: statValuePair("sacks", 0) },
-  ] : [];
+  ].filter((row) => row.value != null) : [];
   const recapScoring = Array.isArray(recapGame?.scoringSummary) ? recapGame.scoringSummary.slice(-2) : [];
   const recapDrives = Array.isArray(recapGame?.driveSummary) ? recapGame.driveSummary.slice(-2) : [];
 
@@ -1093,7 +1093,7 @@ export default function LiveGame({
             }}
           >
             {/* User's finished game (GAME_EVENT received) */}
-            {userResolvedEvents.map((ev, i) => (
+            {!finalFraming && userResolvedEvents.map((ev, i) => (
               <MatchupCard
                 key={ev.gameId ?? i}
                 event={ev}
@@ -1117,7 +1117,7 @@ export default function LiveGame({
             {/* Post-sim fallback: show user's lastResult if no events (e.g. skip was used) */}
             {isFinished &&
               userResolvedEvents.length === 0 &&
-              userLastResults.map((r, i) => (
+              !finalFraming && userLastResults.map((r, i) => (
                 <MatchupCard
                   key={i}
                   event={{

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -126,18 +126,18 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
     // the scorebug shows the period label + possession instead of a fake clock.
     clock: null,
     progressLabel: finished
-      ? 'Final'
+      ? null
       : (useCanonical
         ? null
         : `Play ${Math.min(index + 1, events.length)} of ${events.length}`),
-    downDistance: useCanonical
+    downDistance: finished ? null : useCanonical
       ? (currentEvent.plays != null ? `${currentEvent.plays} plays · ${currentEvent.yards || 0} yds` : 'Drive update')
       : (currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update'),
-    ballSpot: useCanonical
+    ballSpot: finished ? null : useCanonical
       ? '—'
       : (currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --'),
     fieldPosition: currentEvent.fieldPosition,
-    possessionTeamId: currentEvent.possessionTeamId,
+    possessionTeamId: finished ? null : currentEvent.possessionTeamId,
     isFinal: finished,
   };
   const isLateGame = useCanonical
@@ -170,7 +170,7 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
       <header className="watch-header">
         <Scorebug homeTeam={homeTeam} awayTeam={awayTeam} state={scoreState} />
         <div className="watch-state-strip">
-          <span className="watch-mode-chip">{modeLabel}</span>
+          {!finished ? <span className="watch-mode-chip">{modeLabel}</span> : null}
           {/* Honest framing: the drive-by-drive order and the running score shown
               before the final are a deterministic RECONSTRUCTION of possessions,
               not the game's recorded chronology (the engine simulates each side's
@@ -185,10 +185,10 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
             </span>
           ) : null}
           {isLateGame && !finished ? <span className="watch-mode-chip clutch">Late Game</span> : null}
-          {finished ? <span className="watch-mode-chip final">Complete</span> : null}
+          {finished ? <span className="watch-mode-chip final">Final</span> : null}
           {(() => {
             const tc = TENDENCY_CONFIG[userTendency] || TENDENCY_CONFIG.BALANCED;
-            return <span className={`watch-mode-chip tendency-${tc.chipClass}`}>{tc.label}</span>;
+            return !finished ? <span className={`watch-mode-chip tendency-${tc.chipClass}`}>{tc.label}</span> : null;
           })()}
         </div>
         {momentBanner ? <div className={`watch-moment-banner ${momentBanner.type}`} role="status">{momentBanner.text}</div> : null}
@@ -196,14 +196,14 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
 
       <main className="watch-main">
         <section className="watch-panel">
-          <div className={`momentum ${swing.tone}`}>Momentum: {swing.label}</div>
-          <div className="jump-row" role="group" aria-label="Jump to game moments">
+          {!finished ? <div className={`momentum ${swing.tone}`}>Momentum: {swing.label}</div> : null}
+          {!finished ? <div className="jump-row" role="group" aria-label="Jump to game moments">
             <JumpBtn label="Scores" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))} />
             <JumpBtn label="Red Zone" onClick={() => setIndex(getNextImportantEvent(events, index, 'redZone'))} />
             <JumpBtn label="Turnovers" onClick={() => setIndex(getNextImportantEvent(events, index, 'turnover'))} />
             <JumpBtn label="Late Game" onClick={() => setIndex(getNextImportantEvent(events, index, 'finalMinutes'))} />
             <JumpBtn label="End" onClick={() => setIndex(events.length - 1)} />
-          </div>
+          </div> : null}
           <GameEventFeed events={events} activeIndex={index} />
         </section>
 
@@ -251,7 +251,7 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
 
       {/* Compact sticky control tray — one row of playback controls above the
           safe area so the feed owns the screen on mobile. */}
-      <footer className="watch-controls-tray" aria-label="Playback controls">
+      {!finished ? <footer className="watch-controls-tray" aria-label="Playback controls">
         <button
           className="ctrl-btn pause-btn"
           onClick={() => setPaused((prev) => !prev)}
@@ -289,7 +289,7 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
             ) : null}
           </div>
         </details>
-      </footer>
+      </footer> : null}
     </div>
   );
 }

--- a/src/ui/components/Scorebug/Scorebug.jsx
+++ b/src/ui/components/Scorebug/Scorebug.jsx
@@ -57,11 +57,10 @@ export default function Scorebug({ homeTeam, awayTeam, state }) {
         {scoreCell(awayScore, awayTeam?.abbr || 'Away')}
       </div>
       <div className="sb-center">
-        <div>{periodLabel}{possessionAbbr ? ` · ${possessionAbbr} possession` : (state?.progressLabel ? ` · ${state.progressLabel}` : '')}</div>
-        <div>{state?.downDistance || '—'} · {state?.ballSpot || 'Ball on --'}</div>
+        <div>{isFinal ? 'Final' : `${periodLabel}${possessionAbbr ? ` · ${possessionAbbr} possession` : (state?.progressLabel ? ` · ${state.progressLabel}` : '')}`}</div>
+        {!isFinal ? <div>{state?.downDistance || '—'} · {state?.ballSpot || 'Ball on --'}</div> : null}
         <div className="sb-flags">
-          {isFinal ? <span className="sb-flag final">FINAL</span> : null}
-          {isOvertime ? <span className="sb-flag overtime">OVERTIME</span> : null}
+          {isOvertime && !isFinal ? <span className="sb-flag overtime">OVERTIME</span> : null}
           {inRedZone && !isFinal ? <span className="sb-flag redzone">RED ZONE</span> : null}
         </div>
       </div>

--- a/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
@@ -72,6 +72,8 @@ describe('LiveGameViewer — canonical event ledger', () => {
     // At the terminal marker the scorebug reads "Final", never "Drive 3 of 2".
     expect(within(bug).getByText(/Final/)).toBeTruthy();
     expect(within(bug).queryByText(/of 3/)).toBeNull();
+    expect(bug.textContent).not.toMatch(/Final\s*·\s*Final/i);
+    expect(bug.textContent).not.toMatch(/0 plays|0 yds|possession/i);
   });
 
   it('labels the intermediate progression honestly with a "Reconstructed order" chip during playback (post-review point 2)', () => {
@@ -171,6 +173,10 @@ describe('LiveGameViewer — canonical event ledger', () => {
     expect(finalCard).toBeTruthy();
     expect(finalCard.textContent).toContain('MIA 7');
     expect(finalCard.textContent).toContain('BUF 3');
+    expect(screen.queryByRole('group', { name: /Playback speed/i })).toBeNull();
+    expect(screen.queryByLabelText(/Skip options/i)).toBeNull();
+    expect(screen.queryByText(/Momentum:/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /Open Final Game Book/i })).toBeTruthy();
   });
 
   it('mapCanonicalEventsToLiveFeed carries scoreAfter on every event and stamps score chips only on scoring events', () => {
@@ -190,5 +196,21 @@ describe('LiveGameViewer — canonical event ledger', () => {
       prevHome = e.scoreAfter.home;
     });
     expect(feed[feed.length - 1].scoreAfter).toEqual(canonicalFinal);
+  });
+
+  it('labels only the terminal score as FINAL in the event feed', () => {
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="instant"
+        finalScore={canonicalFinal}
+      />,
+    );
+    const scores = [...document.querySelectorAll('.feed-score')].map((node) => node.textContent);
+    expect(scores).toContain('0–7');
+    expect(scores).not.toContain('FINAL 0–7');
+    expect(scores.filter((score) => score.startsWith('FINAL '))).toEqual(['FINAL 3–7']);
   });
 });

--- a/src/ui/utils/postgameEmotionalFrame.js
+++ b/src/ui/utils/postgameEmotionalFrame.js
@@ -10,6 +10,18 @@ function num(v, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+// Result contracts evolved from *Yards to the canonical *Yd names. Preserve
+// missingness: an absent metric is not a recorded zero and cannot support a
+// negative postgame conclusion.
+function readStat(stats, keys) {
+  for (const key of keys) {
+    if (stats?.[key] == null || stats[key] === '') continue;
+    const value = Number(stats[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
 function toId(raw) {
   if (raw == null) return NaN;
   if (typeof raw === 'object') return num(raw.id, NaN);
@@ -75,14 +87,14 @@ function deriveBiggestConcern(opts) {
   }
 
   const userOffSide = userIsHome ? teamStats?.home : teamStats?.away;
-  const turnoversCommitted = num(userOffSide?.turnovers, 0);
-  if (turnoversCommitted >= 3) {
+  const turnoversCommitted = readStat(userOffSide, ['turnovers', 'turnoversCommitted']);
+  if (turnoversCommitted != null && turnoversCommitted >= 3) {
     return { label: 'Turnover problem', detail: `Gave the ball away ${turnoversCommitted} times — cannot sustain that going forward.`, tone: 'warning' };
   }
 
-  const passYds = num(userOffSide?.passYds, 0);
-  const rushYds = num(userOffSide?.rushYds, 0);
-  if (passYds < 150 && rushYds < 80) {
+  const passYds = readStat(userOffSide, ['passYd', 'passYards', 'passYds']);
+  const rushYds = readStat(userOffSide, ['rushYd', 'rushYards', 'rushYds']);
+  if (passYds != null && rushYds != null && passYds < 150 && rushYds < 80) {
     return { label: 'Offense stalled', detail: 'Struggling to move the chains in both phases — game plan needs adjustment.', tone: 'warning' };
   }
 

--- a/src/ui/utils/postgameEmotionalFrame.test.js
+++ b/src/ui/utils/postgameEmotionalFrame.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildPostgameEmotionalFrame } from './postgameEmotionalFrame.js';
+
+function concern(stats) {
+  return buildPostgameEmotionalFrame({
+    homeId: 1,
+    awayId: 2,
+    userTeamId: 1,
+    homeScore: 21,
+    awayScore: 24,
+    teamStats: { home: stats, away: {} },
+  })?.biggestConcern?.label;
+}
+
+describe('postgame emotional stat evidence', () => {
+  it.each([
+    { passYd: 220, rushYd: 134 },
+    { passYards: 220, rushYards: 134 },
+  ])('does not call recorded productive offense stalled (%o)', (stats) => {
+    expect(concern(stats)).not.toBe('Offense stalled');
+  });
+
+  it('does not turn missing offense stats into zero', () => {
+    expect(concern({ turnovers: 1 })).not.toBe('Offense stalled');
+  });
+
+  it('retains the concern when both recorded metrics support it', () => {
+    expect(concern({ passYd: 119, rushYd: 57 })).toBe('Offense stalled');
+  });
+});

--- a/src/ui/utils/weeklyStoryPresentation.js
+++ b/src/ui/utils/weeklyStoryPresentation.js
@@ -7,8 +7,8 @@ export async function loadWeeklyStoryArchivedGame({ getBoxScore, gameId } = {}) 
 }
 
 /** Resolves factual next-game context from the saved schedule without mutation. */
-export function buildNextWeekStoryContext(league = {}) {
-  const week = league?.week;
+export function buildNextWeekStoryContext(league = {}, { completedWeek = null } = {}) {
+  const currentWeek = number(league?.week);
   const userTeamId = league?.userTeamId;
   const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
   const teamId = (side) => side?.id ?? side;
@@ -16,9 +16,19 @@ export function buildNextWeekStoryContext(league = {}) {
     const ids = [Number(teamId(game?.homeId ?? game?.home)), Number(teamId(game?.awayId ?? game?.away))];
     return ids.includes(Number(first)) && (second == null || ids.includes(Number(second)));
   };
-  const weekRow = weeks.find((row) => Number(row?.week) === Number(week));
+  // During the postgame transition the worker and React can briefly disagree
+  // about whether league.week still names the completed week or the upcoming
+  // week. Anchor on the completed result when supplied, then choose the first
+  // actual scheduled user game after it (which also handles byes).
+  const eligibleWeeks = weeks
+    .filter((row) => completedWeek == null
+      ? Number(row?.week) >= Number(currentWeek)
+      : Number(row?.week) > Number(completedWeek))
+    .sort((a, b) => Number(a?.week) - Number(b?.week));
+  const weekRow = eligibleWeeks.find((row) => (row?.games ?? []).some((game) => involves(game, userTeamId)));
+  const week = weekRow?.week ?? (completedWeek == null ? currentWeek : null);
   const matchup = (weekRow?.games ?? []).find((game) => involves(game, userTeamId));
-  if (!matchup) return { week };
+  if (!matchup) return week == null ? null : { week };
   const homeId = teamId(matchup?.homeId ?? matchup?.home);
   const awayId = teamId(matchup?.awayId ?? matchup?.away);
   const opponentId = Number(homeId) === Number(userTeamId) ? awayId : homeId;

--- a/src/ui/utils/weeklyStoryPresentation.test.js
+++ b/src/ui/utils/weeklyStoryPresentation.test.js
@@ -128,6 +128,22 @@ describe('buildWeeklyStoryPresentation', () => {
     expect(JSON.stringify(weeks)).toBe(before);
   });
 
+  it('anchors postgame context after the completed week and skips byes', () => {
+    const context = buildNextWeekStoryContext({
+      week: 5,
+      userTeamId: 1,
+      teams: [{ id: 1, abbr: 'BUF' }, { id: 2, abbr: 'MIA' }, { id: 3, abbr: 'KC' }],
+      schedule: { weeks: [
+        { week: 4, games: [{ home: 1, away: 2 }] },
+        { week: 5, games: [] },
+        { week: 6, games: [{ home: 3, away: 1 }] },
+      ] },
+    }, { completedWeek: 4 });
+    expect(context.week).toBe(6);
+    expect(context.opponentAbbr).toBe('KC');
+    expect(context.previousMeetingWeek).toBeNull();
+  });
+
   it('degrades for bye weeks, old saves, and missing identities', () => {
     const vm = buildWeeklyStoryPresentation({ league: {}, week: 8, completedGames: [], injuries: [{ injuryWeeksRemaining: 5 }] });
     expect(vm.userGameStory).toBeNull();


### PR DESCRIPTION
### Motivation
- Audited `main` at `d600336a502c5e03b0b08c1cfc10ee1e8f58f391` and fixed presentation-integrity defects that make the weekly loop produce duplicate, fabricated, or contradictory final-state information on Watch → Postgame → Weekly Results → HQ surfaces. 
- Root-causes found: event feed labeled intermediate scoring chips as FINAL, scorebug concatenated redundant final labels while rendering terminal drive fields, finished Watch kept active playback/tactical controls and live momentum, and postgame narrative code treated missing stats as numeric zero causing false takeaways. 
- Goal: restore a single authoritative final, suppress fabricated drive metadata at terminal state, preserve truthful running scores during playback, respect missing-data semantics, and ensure next-opponent resolution is anchored to the completed-week schedule.

### Description
- Game event feed and live viewer: only the terminal `game_end` event is prefixed with `FINAL`, the scorebug suppresses terminal drive play/yard/possession fields and avoids duplicate final labels, and the Watch viewer hides pause/speed/skip/tendency/momentum/jump controls when finished while keeping event history and a primary `Open Final Game Book` CTA. 
- Postgame narrative and stat access: added `readStat` helpers to preserve missingness and accept canonical and legacy aliases (`passYd`/`passYards`/`passYds`, `rushYd`/`rushYards`/`rushYds`), and tightened the "Offense stalled" rule to require both recorded metrics. 
- Next-opponent / weekly context: `buildNextWeekStoryContext` now accepts a `completedWeek` anchor and selects the first subsequent scheduled user game (skipping byes) so Postgame/skip-mode never shows a stale prior opponent. 
- Weekly results / HQ density: metric rows filter out unavailable tiles (but still show known zeros) and the duplicated secondary matchup card beneath the hero final is suppressed while preserving Game Book navigation. 
- Files changed and tests added: modified `LiveGameViewer.jsx`, `GameEventFeed.jsx`, `Scorebug.jsx`, `LiveGame.jsx`, `weeklyStoryPresentation.js`, `postgameEmotionalFrame.js`, and related tests; added `src/ui/utils/postgameEmotionalFrame.test.js` and extended canonical watcher tests. 

### Testing
- Ran targeted Vitest suites for the changed areas: `LiveGameViewerCanonical` + new `postgameEmotionalFrame` + `weeklyStoryPresentation` tests (7 test files, 70 tests) and they passed. 
- Ran `npm run check:sim-types` which completed successfully and `npm run build` which completed successfully with the repository's expected large-chunk warning; both are green. 
- Performed local JS syntax checks (`node --check`) on touched helper files and they passed. 
- Full `npm run test:unit`, soak (`npm run test:soak`), deploy parity, and Playwright E2E smoke were not completed in this environment (the full unit run was started but not allowed to finish), so a full-suite claim is not made; these are listed as follow-ups to run in CI before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f03c96034832da31165a1e63260b8)